### PR TITLE
chore: add issue templates for GitHub workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_regression.yml
+++ b/.github/ISSUE_TEMPLATE/bug_regression.yml
@@ -1,0 +1,59 @@
+name: Bug / Regression
+description: Report a bug, broken behavior, or regression in the application or workflow.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+      placeholder: The transaction preview page crashes when...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest repeatable sequence.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Risk / impact
+      description: Describe user impact, operational risk, or financial control impact.
+      placeholder: Blocks reversals above the override threshold.
+  - type: textarea
+    id: references
+    attributes:
+      label: Related files or flows
+      description: Optional paths, logs, URLs, or related issues.
+      placeholder: |
+        - app/controllers/transactions_controller.rb
+        - docs/00_initial_core_references/posting_lifecycle.md
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test coverage needed
+      description: What automated or manual checks should prevent this in the future?
+      placeholder: Add a controller regression test covering...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Workflow
+    url: https://github.com/BankEncore/bankcore-2/blob/main/docs/github_workflow.md
+    about: Review the repository workflow for branches, commits, pushes, and pull requests.
+  - name: Posting Compliance Matrix
+    url: https://github.com/BankEncore/bankcore-2/blob/main/docs/progress/posting_compliance_matrix.md
+    about: Review known posting lifecycle and posting engine hardening gaps before filing a control-related issue.

--- a/.github/ISSUE_TEMPLATE/feature_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/feature_enhancement.yml
@@ -1,0 +1,64 @@
+name: Feature / Enhancement
+description: Propose a new capability, roadmap item, or meaningful improvement.
+title: "feature: "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome do we want?
+      placeholder: Add a governed teller cash deposit workflow using the existing posting engine.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: Explain the user, operational, or architectural value.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included in this work?
+      placeholder: |
+        - Add ...
+        - Update ...
+        - Expose ...
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What is explicitly not part of this work?
+      placeholder: |
+        - No teller cash counts
+        - No recurring schedules
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete conditions for completion.
+      placeholder: |
+        - User can ...
+        - Service validates ...
+        - Tests cover ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / dependencies
+      description: Note docs, services, migrations, or policy dependencies.
+  - type: textarea
+    id: related_docs
+    attributes:
+      label: Related docs
+      description: Link roadmap or reference docs if applicable.
+      placeholder: |
+        - docs/00_initial_core_references/implementation_order.md
+        - docs/00_initial_core_references/posting_engine_rules.md

--- a/.github/ISSUE_TEMPLATE/hardening_control_gap.yml
+++ b/.github/ISSUE_TEMPLATE/hardening_control_gap.yml
@@ -1,0 +1,62 @@
+name: Hardening / Control Gap
+description: Track a financial safety, governance, immutability, idempotency, or audit control gap.
+title: "hardening: "
+labels:
+  - hardening
+  - financial-controls
+body:
+  - type: textarea
+    id: gap
+    attributes:
+      label: Control gap
+      description: Describe the specific hardening or control gap.
+      placeholder: Posted financial rows can still be mutated after commit.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: Explain the financial, audit, operational, or data-integrity risk.
+    validations:
+      required: true
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: What does the system do today?
+    validations:
+      required: true
+  - type: textarea
+    id: desired_behavior
+    attributes:
+      label: Desired behavior
+      description: What should the system do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: affected_areas
+    attributes:
+      label: Affected services / models
+      description: List the main code paths involved.
+      placeholder: |
+        - app/services/posting_engine.rb
+        - app/models/posting_batch.rb
+        - app/services/reversal_service.rb
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test requirements
+      description: What regression coverage should be added?
+      placeholder: Add rollback coverage for...
+    validations:
+      required: true
+  - type: textarea
+    id: related_docs
+    attributes:
+      label: Related docs
+      description: Link reference docs, audits, or prior issues.
+      placeholder: |
+        - docs/00_initial_core_references/posting_lifecycle.md
+        - docs/00_initial_core_references/posting_engine_rules.md
+        - docs/progress/posting_compliance_matrix.md


### PR DESCRIPTION
## Summary
- add GitHub issue forms for bugs, features, and hardening/control gaps
- add issue template config linking the repo workflow and posting compliance docs
- make the issue intake flow match the labels, milestones, and hardening backlog created in GitHub

## Test plan
- [x] reviewed the new issue template files locally
- [x] confirmed the branch was pushed to GitHub
- [x] verified the repository already has matching labels and milestones for these templates

Made with [Cursor](https://cursor.com)