### PR TITLE
fix(posting): reject conflicting idempotency key reuse

### DIFF
--- a/app/services/fee_posting_service.rb
+++ b/app/services/fee_posting_service.rb
@@ -27,17 +27,20 @@ class FeePostingService
       amount_cents: amount,
       business_date: @business_date,
       idempotency_key: @idempotency_key,
-      gl_account_id: fee_type.gl_account_id
+      gl_account_id: fee_type.gl_account_id,
+      idempotency_context: {
+        service: "fee_posting",
+        fee_type_id: @fee_type_id
+      }
     )
 
-    FeeAssessment.create!(
-      account_id: @account_id,
-      fee_type_id: @fee_type_id,
-      posting_batch_id: batch.id,
-      amount_cents: amount,
-      assessed_on: @business_date,
-      status: Bankcore::Enums::STATUS_POSTED
-    )
+    FeeAssessment.find_or_create_by!(posting_batch_id: batch.id) do |assessment|
+      assessment.account_id = @account_id
+      assessment.fee_type_id = @fee_type_id
+      assessment.amount_cents = amount
+      assessment.assessed_on = @business_date
+      assessment.status = Bankcore::Enums::STATUS_POSTED
+    end
 
     batch
   end

--- a/app/services/interest_accrual_service.rb
+++ b/app/services/interest_accrual_service.rb
@@ -23,16 +23,19 @@ class InterestAccrualService
       account_id: nil,
       amount_cents: @amount_cents,
       business_date: @accrual_date,
-      idempotency_key: @idempotency_key
+      idempotency_key: @idempotency_key,
+      idempotency_context: {
+        service: "interest_accrual",
+        account_id: @account_id
+      }
     )
 
-    InterestAccrual.create!(
-      account_id: @account_id,
-      accrual_date: @accrual_date,
-      amount_cents: @amount_cents,
-      posting_batch_id: batch.id,
-      status: Bankcore::Enums::STATUS_POSTED
-    )
+    InterestAccrual.find_or_create_by!(posting_batch_id: batch.id) do |accrual|
+      accrual.account_id = @account_id
+      accrual.accrual_date = @accrual_date
+      accrual.amount_cents = @amount_cents
+      accrual.status = Bankcore::Enums::STATUS_POSTED
+    end
 
     batch
   end

--- a/app/services/posting_engine.rb
+++ b/app/services/posting_engine.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require "digest"
+
 class PostingEngine
   include Bankcore::Enums
 
   class PostingError < StandardError; end
+  class IdempotencyConflictError < PostingError; end
 
   def self.post!(**params)
     new(**params).post!
@@ -15,7 +18,7 @@ class PostingEngine
 
   def initialize(transaction_code:, account_id: nil, source_account_id: nil, destination_account_id: nil,
                  amount_cents:, business_date: nil, idempotency_key: nil, created_by_id: nil,
-                 gl_account_id: nil, reversal_of_batch_id: nil)
+                 gl_account_id: nil, reversal_of_batch_id: nil, idempotency_context: nil)
     @transaction_code = transaction_code
     @account_id = account_id
     @source_account_id = source_account_id
@@ -26,15 +29,22 @@ class PostingEngine
     @created_by_id = created_by_id
     @gl_account_id = gl_account_id
     @reversal_of_batch_id = reversal_of_batch_id
+    @idempotency_context = idempotency_context
   end
 
   def post!
-    return existing_batch if idempotent_duplicate?
+    existing_batch = matching_idempotent_batch
+    return existing_batch if existing_batch.present?
 
     ActiveRecord::Base.transaction do
       build_and_validate_legs!
       create_posted_records!
     end
+  rescue ActiveRecord::RecordNotUnique
+    existing_batch = matching_idempotent_batch
+    return existing_batch if existing_batch.present?
+
+    raise
   end
 
   def preview!
@@ -52,14 +62,15 @@ class PostingEngine
 
   private
 
-  def idempotent_duplicate?
+  def matching_idempotent_batch
     return false if @idempotency_key.blank?
 
-    PostingBatch.exists?(idempotency_key: @idempotency_key, status: STATUS_POSTED)
-  end
+    batch = PostingBatch.find_by(idempotency_key: @idempotency_key, status: STATUS_POSTED)
+    return false unless batch
+    return batch if idempotency_payload_matches?(batch)
 
-  def existing_batch
-    PostingBatch.find_by!(idempotency_key: @idempotency_key, status: STATUS_POSTED)
+    raise IdempotencyConflictError,
+      "Idempotency key #{@idempotency_key} has already been used for a different request"
   end
 
   def build_and_validate_legs!
@@ -122,8 +133,8 @@ class PostingEngine
       business_date: @business_date,
       posted_at: Time.current,
       transaction_code: @transaction_code,
-      idempotency_key: @idempotency_key,
-      reversal_of_batch_id: @reversal_of_batch_id
+      reversal_of_batch_id: @reversal_of_batch_id,
+      **idempotency_attributes
     )
 
     @legs.each_with_index do |leg, idx|
@@ -159,5 +170,61 @@ class PostingEngine
   def resolve_branch_id
     account = Account.find_by(id: @account_id || @source_account_id || @destination_account_id)
     account&.branch_id || Branch.first&.id
+  end
+
+  def idempotency_attributes
+    return {} if @idempotency_key.blank?
+
+    {
+      idempotency_key: @idempotency_key,
+      idempotency_fingerprint: idempotency_fingerprint,
+      idempotency_payload_json: idempotency_payload_json
+    }
+  end
+
+  def idempotency_payload_matches?(batch)
+    return true if batch.idempotency_fingerprint.blank?
+
+    batch.idempotency_fingerprint == idempotency_fingerprint
+  end
+
+  def idempotency_fingerprint
+    @idempotency_fingerprint ||= Digest::SHA256.hexdigest(idempotency_payload_json)
+  end
+
+  def idempotency_payload_json
+    @idempotency_payload_json ||= JSON.generate(canonicalize_value(semantic_idempotency_payload))
+  end
+
+  def semantic_idempotency_payload
+    payload = {
+      transaction_code: @transaction_code,
+      account_id: @account_id,
+      source_account_id: @source_account_id,
+      destination_account_id: @destination_account_id,
+      amount_cents: @amount_cents,
+      business_date: @business_date&.to_date&.iso8601,
+      gl_account_id: @gl_account_id,
+      reversal_of_batch_id: @reversal_of_batch_id
+    }
+    payload[:context] = @idempotency_context if @idempotency_context.present?
+    payload.compact
+  end
+
+  def canonicalize_value(value)
+    case value
+    when Hash
+      value.keys.sort_by(&:to_s).each_with_object({}) do |key, result|
+        result[key.to_s] = canonicalize_value(value[key])
+      end
+    when Array
+      value.map { |item| canonicalize_value(item) }
+    when Date
+      value.iso8601
+    when Time, ActiveSupport::TimeWithZone
+      value.iso8601
+    else
+      value
+    end
   end
 end

--- a/app/services/reversal_service.rb
+++ b/app/services/reversal_service.rb
@@ -17,7 +17,12 @@ class ReversalService
 
   def reverse!
     raise ReversalError, "Batch is not posted" unless @posting_batch.status == STATUS_POSTED
-    raise ReversalError, "Batch already reversed" if @posting_batch.reversal_batch.present?
+
+    if @posting_batch.reversal_batch.present?
+      return @posting_batch.reversal_batch if idempotent_replay?
+
+      raise ReversalError, "Batch already reversed"
+    end
 
     reversal_code = TransactionCode.find_by(code: @posting_batch.transaction_code)&.reversal_code
     raise ReversalError, "No reversal code for #{@posting_batch.transaction_code}" if reversal_code.blank?
@@ -57,5 +62,9 @@ class ReversalService
       gl_account_id: legs.find { |l| l.gl_account_id.present? }&.gl_account_id
     )
     batch
+  end
+
+  def idempotent_replay?
+    @idempotency_key.present? && @posting_batch.reversal_batch.idempotency_key == @idempotency_key
   end
 end

--- a/db/migrate/20260308191000_add_idempotency_fingerprint_to_posting_batches.rb
+++ b/db/migrate/20260308191000_add_idempotency_fingerprint_to_posting_batches.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIdempotencyFingerprintToPostingBatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :posting_batches, :idempotency_fingerprint, :string
+    add_column :posting_batches, :idempotency_payload_json, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_08_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_08_191000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -246,7 +246,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_08_130000) do
   create_table "posting_batches", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.date "business_date", null: false
     t.datetime "created_at", null: false
+    t.string "idempotency_fingerprint"
     t.string "idempotency_key"
+    t.text "idempotency_payload_json"
     t.bigint "operational_transaction_id"
     t.datetime "posted_at"
     t.string "posting_reference"

--- a/test/services/fee_posting_service_test.rb
+++ b/test/services/fee_posting_service_test.rb
@@ -53,6 +53,59 @@ class FeePostingServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "duplicate idempotency key reuses batch without duplicate assessment" do
+    key = "fee-idem-#{SecureRandom.hex(8)}"
+
+    batch1 = FeePostingService.assess!(
+      account_id: @account.id,
+      fee_type_id: @fee_type.id,
+      amount_cents: 2500,
+      business_date: @business_date,
+      idempotency_key: key
+    )
+
+    assert_no_difference "FeeAssessment.count" do
+      batch2 = FeePostingService.assess!(
+        account_id: @account.id,
+        fee_type_id: @fee_type.id,
+        amount_cents: 2500,
+        business_date: @business_date,
+        idempotency_key: key
+      )
+
+      assert_equal batch1.id, batch2.id
+    end
+  end
+
+  test "idempotency rejects conflicting fee_type reuse" do
+    other_fee_type = FeeType.create!(
+      code: "OTHER_FEE",
+      name: "Other Fee",
+      default_amount_cents: 1000,
+      gl_account_id: @fee_type.gl_account_id,
+      status: Bankcore::Enums::STATUS_ACTIVE
+    )
+    key = "fee-idem-#{SecureRandom.hex(8)}"
+
+    FeePostingService.assess!(
+      account_id: @account.id,
+      fee_type_id: @fee_type.id,
+      amount_cents: 2500,
+      business_date: @business_date,
+      idempotency_key: key
+    )
+
+    assert_raises(PostingEngine::IdempotencyConflictError) do
+      FeePostingService.assess!(
+        account_id: @account.id,
+        fee_type_id: other_fee_type.id,
+        amount_cents: 2500,
+        business_date: @business_date,
+        idempotency_key: key
+      )
+    end
+  end
+
   private
 
   def ensure_fee_post_template!

--- a/test/services/interest_accrual_service_test.rb
+++ b/test/services/interest_accrual_service_test.rb
@@ -5,6 +5,14 @@ require "test_helper"
 class InterestAccrualServiceTest < ActiveSupport::TestCase
   def setup
     @account = accounts(:one)
+    @other_account = Account.create!(
+      account_number: "2002",
+      account_type: @account.account_type,
+      branch: @account.branch,
+      currency_code: @account.currency_code,
+      status: Bankcore::Enums::STATUS_ACTIVE,
+      opened_on: @account.opened_on
+    )
     @accrual_date = business_dates(:one).business_date
     ensure_int_accrual_template!
   end
@@ -30,6 +38,48 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
         account_id: @account.id,
         amount_cents: -100,
         accrual_date: @accrual_date
+      )
+    end
+  end
+
+  test "duplicate idempotency key reuses batch without duplicate accrual" do
+    key = "accrual-idem-#{SecureRandom.hex(8)}"
+
+    batch1 = InterestAccrualService.accrue!(
+      account_id: @account.id,
+      amount_cents: 150,
+      accrual_date: @accrual_date,
+      idempotency_key: key
+    )
+
+    assert_no_difference "InterestAccrual.count" do
+      batch2 = InterestAccrualService.accrue!(
+        account_id: @account.id,
+        amount_cents: 150,
+        accrual_date: @accrual_date,
+        idempotency_key: key
+      )
+
+      assert_equal batch1.id, batch2.id
+    end
+  end
+
+  test "idempotency rejects conflicting accrual account reuse" do
+    key = "accrual-idem-#{SecureRandom.hex(8)}"
+
+    InterestAccrualService.accrue!(
+      account_id: @account.id,
+      amount_cents: 150,
+      accrual_date: @accrual_date,
+      idempotency_key: key
+    )
+
+    assert_raises(PostingEngine::IdempotencyConflictError) do
+      InterestAccrualService.accrue!(
+        account_id: @other_account.id,
+        amount_cents: 150,
+        accrual_date: @accrual_date,
+        idempotency_key: key
       )
     end
   end

--- a/test/services/posting_engine_test.rb
+++ b/test/services/posting_engine_test.rb
@@ -71,6 +71,29 @@ class PostingEngineTest < ActiveSupport::TestCase
     assert_equal batch1.id, batch2.id
   end
 
+  test "idempotency rejects conflicting payload reuse" do
+    key = "idem-#{SecureRandom.hex(8)}"
+    PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: @account.id,
+      amount_cents: 2500,
+      business_date: @business_date,
+      idempotency_key: key
+    )
+
+    error = assert_raises(PostingEngine::IdempotencyConflictError) do
+      PostingEngine.post!(
+        transaction_code: "ADJ_CREDIT",
+        account_id: @account.id,
+        amount_cents: 5000,
+        business_date: @business_date,
+        idempotency_key: key
+      )
+    end
+
+    assert_match "different request", error.message
+  end
+
   test "raises when no template exists" do
     assert_raises(PostingEngine::PostingError) do
       PostingEngine.post!(

--- a/test/services/reversal_service_test.rb
+++ b/test/services/reversal_service_test.rb
@@ -66,4 +66,13 @@ class ReversalServiceTest < ActiveSupport::TestCase
     assert override.used_at.present?
     assert_equal "used", override.status
   end
+
+  test "idempotent reversal retry returns existing reversal batch" do
+    key = "reversal-idem-#{SecureRandom.hex(8)}"
+
+    reversal_batch = ReversalService.reverse!(posting_batch: @batch, idempotency_key: key)
+    replay_batch = ReversalService.reverse!(posting_batch: @batch, idempotency_key: key)
+
+    assert_equal reversal_batch.id, replay_batch.id
+  end
 end


### PR DESCRIPTION
## Summary
- persist semantic idempotency fingerprints on posting batches and reject same-key retries when the request intent differs
- extend idempotency context for fee posting and interest accrual so service-specific semantics are compared, not just raw posting legs
- keep same-key retries idempotent end to end by reusing existing fee assessments, interest accruals, and reversal batches instead of creating duplicates

Closes #6.

## Test plan
- [x] `bin/rails db:migrate`
- [x] `bin/rails test test/services/posting_engine_test.rb test/services/fee_posting_service_test.rb test/services/interest_accrual_service_test.rb test/services/reversal_service_test.rb`
- [x] `bin/rubocop app/services/posting_engine.rb app/services/fee_posting_service.rb app/services/interest_accrual_service.rb app/services/reversal_service.rb test/services/posting_engine_test.rb test/services/fee_posting_service_test.rb test/services/interest_accrual_service_test.rb test/services/reversal_service_test.rb db/migrate/20260308191000_add_idempotency_fingerprint_to_posting_batches.rb`
- [x] `bin/rails test`

## Data/migration impact
- adds `idempotency_fingerprint` and `idempotency_payload_json` to `posting_batches`
- no backfill is included; new and future posted batches get strict conflict detection semantics

## Financial logic risk
- medium-low
- changes are contained to idempotency enforcement and retry handling, with regression coverage for posting, fee, accrual, and reversal flows

Made with [Cursor](https://cursor.com)