### PR TITLE
fix(posting): harden pre-teller financial controls

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -19,25 +19,10 @@ class TransactionsController < ApplicationController
     batch = @transaction.posting_batch
     raise ActiveRecord::RecordNotFound, "No posting batch" unless batch
 
-    amount_cents = batch.posting_legs.sum(:amount_cents)
-    threshold = Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS
-
-    if amount_cents >= threshold
-      override = OverrideRequest.usable.find_by(
-        operational_transaction_id: @transaction.id,
-        request_type: Bankcore::Enums::OVERRIDE_TYPE_REVERSAL
-      )
-      unless override
-        redirect_to new_override_request_path(transaction_id: @transaction.id, request_type: "reversal"),
-          alert: "Reversals of #{helpers.number_to_currency(threshold / 100.0)} or more require supervisor approval. Please request an override first."
-        return
-      end
-      ReversalService.reverse!(posting_batch: batch, override_request: override)
-    else
-      ReversalService.reverse!(posting_batch: batch)
-    end
-
+    ReversalService.reverse!(posting_batch: batch)
     redirect_to transaction_path(@transaction), notice: "Transaction reversed successfully."
+  rescue ReversalService::OverrideRequiredError => e
+    redirect_to new_override_request_path(transaction_id: @transaction.id, request_type: "reversal"), alert: e.message
   rescue ReversalService::ReversalError, OverrideRequestService::OverrideError => e
     redirect_to transaction_path(@transaction), alert: "Reversal failed: #{e.message}"
   end

--- a/app/models/account_transaction.rb
+++ b/app/models/account_transaction.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountTransaction < ApplicationRecord
+  include PostedRecordImmutable
+
   belongs_to :account
   belongs_to :posting_batch
 
@@ -16,4 +18,10 @@ class AccountTransaction < ApplicationRecord
   validates :posting_batch_id, presence: true
   validates :amount_cents, presence: true, numericality: { only_integer: true }
   validates :direction, presence: true, inclusion: { in: %w[debit credit] }
+
+  private
+
+  def posted_record_immutable?
+    posting_batch.status == Bankcore::Enums::STATUS_POSTED
+  end
 end

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -2,7 +2,7 @@
 
 class AuditEvent < ApplicationRecord
   # Polymorphic: actor and target can be various types
-  # event_type: posting_succeeded, posting_failed, reversal_created, fee_assessed, interest_accrued, etc.
+  # event_type: posting_requested, posting_committed, posting_failed, reversal_requested, reversal_committed, etc.
   # metadata_json: JSON string for additional context
 
   validates :event_type, presence: true

--- a/app/models/concerns/posted_record_immutable.rb
+++ b/app/models/concerns/posted_record_immutable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PostedRecordImmutable
+  extend ActiveSupport::Concern
+
+  included do
+    before_update :prevent_posted_record_mutation
+    before_destroy :prevent_posted_record_destruction
+  end
+
+  private
+
+  def prevent_posted_record_mutation
+    prevent_posted_record_change("cannot be updated once posted") if posted_record_immutable?
+  end
+
+  def prevent_posted_record_destruction
+    prevent_posted_record_change("cannot be deleted once posted") if posted_record_immutable?
+  end
+
+  def prevent_posted_record_change(message)
+    errors.add(:base, message)
+    throw(:abort)
+  end
+end

--- a/app/models/journal_entry.rb
+++ b/app/models/journal_entry.rb
@@ -2,6 +2,7 @@
 
 class JournalEntry < ApplicationRecord
   include Bankcore::Enums
+  include PostedRecordImmutable
 
   belongs_to :posting_batch
   has_many :journal_entry_lines, dependent: :destroy
@@ -9,4 +10,10 @@ class JournalEntry < ApplicationRecord
   validates :posting_batch_id, presence: true
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::POSTING_STATUSES }
   validates :business_date, presence: true
+
+  private
+
+  def posted_record_immutable?
+    status == STATUS_POSTED
+  end
 end

--- a/app/models/journal_entry_line.rb
+++ b/app/models/journal_entry_line.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class JournalEntryLine < ApplicationRecord
+  include PostedRecordImmutable
+
   belongs_to :journal_entry
   belongs_to :gl_account
   belongs_to :branch, optional: true
@@ -9,4 +11,10 @@ class JournalEntryLine < ApplicationRecord
   validates :gl_account_id, presence: true
   validates :debit_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :credit_cents, numericality: { greater_than_or_equal_to: 0 }
+
+  private
+
+  def posted_record_immutable?
+    journal_entry.status == Bankcore::Enums::STATUS_POSTED
+  end
 end

--- a/app/models/posting_batch.rb
+++ b/app/models/posting_batch.rb
@@ -2,6 +2,7 @@
 
 class PostingBatch < ApplicationRecord
   include Bankcore::Enums
+  include PostedRecordImmutable
 
   belongs_to :operational_transaction, class_name: "BankingTransaction", optional: true
   belongs_to :reversal_of_batch, class_name: "PostingBatch", optional: true
@@ -14,6 +15,29 @@ class PostingBatch < ApplicationRecord
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::POSTING_STATUSES }
   validates :business_date, presence: true
   validates :transaction_code, presence: true
+  validates :posting_reference, uniqueness: true, allow_nil: true
 
   scope :posted, -> { where(status: Bankcore::Enums::STATUS_POSTED) }
+
+  before_validation :assign_posting_reference, on: :create
+
+  def posted_record_immutable?
+    status == STATUS_POSTED
+  end
+
+  private
+
+  def assign_posting_reference
+    return if posting_reference.present?
+    return unless status == STATUS_POSTED
+
+    self.posting_reference = generate_posting_reference
+  end
+
+  def generate_posting_reference
+    loop do
+      candidate = "PB-#{Time.current.utc.strftime('%Y%m%d')}-#{SecureRandom.hex(6).upcase}"
+      return candidate unless self.class.exists?(posting_reference: candidate)
+    end
+  end
 end

--- a/app/models/posting_leg.rb
+++ b/app/models/posting_leg.rb
@@ -2,6 +2,7 @@
 
 class PostingLeg < ApplicationRecord
   include Bankcore::Enums
+  include PostedRecordImmutable
 
   belongs_to :posting_batch
   belongs_to :gl_account, optional: true
@@ -13,6 +14,10 @@ class PostingLeg < ApplicationRecord
   validate :has_target
 
   private
+
+  def posted_record_immutable?
+    posting_batch.status == STATUS_POSTED
+  end
 
   def has_target
     return if gl_account_id.present? ^ account_id.present?

--- a/app/services/account_projector.rb
+++ b/app/services/account_projector.rb
@@ -22,7 +22,7 @@ class AccountProjector
         posting_batch_id: @posting_batch.id,
         amount_cents: leg.amount_cents,
         direction: leg.leg_type,
-        description: "#{@posting_batch.transaction_code} ##{@posting_batch.id}",
+        description: [ @posting_batch.transaction_code, @posting_batch.posting_reference ].compact.join(" "),
         business_date: @posting_batch.business_date,
         posted_at: @posting_batch.posted_at
       )

--- a/app/services/audit_emission_service.rb
+++ b/app/services/audit_emission_service.rb
@@ -3,9 +3,15 @@
 class AuditEmissionService
   include Bankcore::Enums
 
-  EVENT_POSTING_SUCCEEDED = "posting_succeeded"
+  EVENT_POSTING_REQUESTED = "posting_requested"
+  EVENT_POSTING_COMMITTED = "posting_committed"
   EVENT_POSTING_FAILED = "posting_failed"
-  EVENT_REVERSAL_CREATED = "reversal_created"
+  EVENT_REVERSAL_REQUESTED = "reversal_requested"
+  EVENT_REVERSAL_COMMITTED = "reversal_committed"
+  EVENT_OVERRIDE_REQUESTED = "override_requested"
+  EVENT_OVERRIDE_APPROVED = "override_approved"
+  EVENT_OVERRIDE_DENIED = "override_denied"
+  EVENT_OVERRIDE_USED = "override_used"
   EVENT_FEE_ASSESSED = "fee_assessed"
   EVENT_INTEREST_ACCRUED = "interest_accrued"
   EVENT_INTEREST_POSTED = "interest_posted"

--- a/app/services/business_date_eod_service.rb
+++ b/app/services/business_date_eod_service.rb
@@ -24,11 +24,19 @@ class BusinessDateEodService
       next_bd.save!
 
       AuditEmissionService.emit!(
-        event_type: "business_date_closed",
+        event_type: AuditEmissionService::EVENT_BUSINESS_DATE_CLOSED,
         action: "close",
         target: current,
         business_date: current.business_date,
         metadata: { closed_date: current.business_date.to_s, opened_date: next_date.to_s }
+      )
+
+      AuditEmissionService.emit!(
+        event_type: AuditEmissionService::EVENT_BUSINESS_DATE_OPENED,
+        action: "open",
+        target: next_bd,
+        business_date: next_date,
+        metadata: { opened_date: next_date.to_s, prior_date: current.business_date.to_s }
       )
     end
 

--- a/app/services/fee_posting_service.rb
+++ b/app/services/fee_posting_service.rb
@@ -21,27 +21,29 @@ class FeePostingService
     amount = @amount_cents || fee_type.default_amount_cents
     raise ArgumentError, "Amount must be positive" if amount.to_i <= 0
 
-    batch = PostingEngine.post!(
-      transaction_code: "FEE_POST",
-      account_id: @account_id,
-      amount_cents: amount,
-      business_date: @business_date,
-      idempotency_key: @idempotency_key,
-      gl_account_id: fee_type.gl_account_id,
-      idempotency_context: {
-        service: "fee_posting",
-        fee_type_id: @fee_type_id
-      }
-    )
+    ActiveRecord::Base.transaction do
+      batch = PostingEngine.post!(
+        transaction_code: "FEE_POST",
+        account_id: @account_id,
+        amount_cents: amount,
+        business_date: @business_date,
+        idempotency_key: @idempotency_key,
+        gl_account_id: fee_type.gl_account_id,
+        idempotency_context: {
+          service: "fee_posting",
+          fee_type_id: @fee_type_id
+        }
+      )
 
-    FeeAssessment.find_or_create_by!(posting_batch_id: batch.id) do |assessment|
-      assessment.account_id = @account_id
-      assessment.fee_type_id = @fee_type_id
-      assessment.amount_cents = amount
-      assessment.assessed_on = @business_date
-      assessment.status = Bankcore::Enums::STATUS_POSTED
+      FeeAssessment.find_or_create_by!(posting_batch_id: batch.id) do |assessment|
+        assessment.account_id = @account_id
+        assessment.fee_type_id = @fee_type_id
+        assessment.amount_cents = amount
+        assessment.assessed_on = @business_date
+        assessment.status = Bankcore::Enums::STATUS_POSTED
+      end
+
+      batch
     end
-
-    batch
   end
 end

--- a/app/services/interest_accrual_service.rb
+++ b/app/services/interest_accrual_service.rb
@@ -18,25 +18,27 @@ class InterestAccrualService
   def accrue!
     raise ArgumentError, "Amount must be non-negative" if @amount_cents.to_i < 0
 
-    batch = PostingEngine.post!(
-      transaction_code: "INT_ACCRUAL",
-      account_id: nil,
-      amount_cents: @amount_cents,
-      business_date: @accrual_date,
-      idempotency_key: @idempotency_key,
-      idempotency_context: {
-        service: "interest_accrual",
-        account_id: @account_id
-      }
-    )
+    ActiveRecord::Base.transaction do
+      batch = PostingEngine.post!(
+        transaction_code: "INT_ACCRUAL",
+        account_id: nil,
+        amount_cents: @amount_cents,
+        business_date: @accrual_date,
+        idempotency_key: @idempotency_key,
+        idempotency_context: {
+          service: "interest_accrual",
+          account_id: @account_id
+        }
+      )
 
-    InterestAccrual.find_or_create_by!(posting_batch_id: batch.id) do |accrual|
-      accrual.account_id = @account_id
-      accrual.accrual_date = @accrual_date
-      accrual.amount_cents = @amount_cents
-      accrual.status = Bankcore::Enums::STATUS_POSTED
+      InterestAccrual.find_or_create_by!(posting_batch_id: batch.id) do |accrual|
+        accrual.account_id = @account_id
+        accrual.accrual_date = @accrual_date
+        accrual.amount_cents = @amount_cents
+        accrual.status = Bankcore::Enums::STATUS_POSTED
+      end
+
+      batch
     end
-
-    batch
   end
 end

--- a/app/services/journal_projector.rb
+++ b/app/services/journal_projector.rb
@@ -14,7 +14,10 @@ class JournalProjector
 
     JournalEntry.transaction do
       journal_entry = create_journal_entry
-      create_journal_lines(journal_entry)
+      create_journal_lines(
+        journal_entry,
+        @posting_batch.posting_legs.where(ledger_scope: Bankcore::Enums::LEDGER_SCOPE_GL)
+      )
     end
   end
 
@@ -23,15 +26,14 @@ class JournalProjector
   def create_journal_entry
     JournalEntry.create!(
       posting_batch_id: @posting_batch.id,
-      reference_number: "JE-#{@posting_batch.id}",
+      reference_number: @posting_batch.posting_reference,
       status: Bankcore::Enums::STATUS_POSTED,
       business_date: @posting_batch.business_date,
       posted_at: @posting_batch.posted_at
     )
   end
 
-  def create_journal_lines(journal_entry)
-    gl_legs = @posting_batch.posting_legs.where(ledger_scope: Bankcore::Enums::LEDGER_SCOPE_GL)
+  def create_journal_lines(journal_entry, gl_legs)
     branch_id = resolve_branch_id
 
     gl_legs.each_with_index do |leg, idx|

--- a/app/services/override_request_service.rb
+++ b/app/services/override_request_service.rb
@@ -44,7 +44,7 @@ class OverrideRequestService
   def request!
     raise OverrideError, "Invalid request type" unless OVERRIDE_TYPES.include?(@request_type)
 
-    OverrideRequest.create!(
+    override_request = OverrideRequest.create!(
       request_type: @request_type,
       status: OVERRIDE_STATUS_PENDING,
       requested_by_id: @requested_by_id,
@@ -53,6 +53,18 @@ class OverrideRequestService
       reason_text: @reason_text,
       expires_at: @expires_at
     )
+
+    AuditEmissionService.emit!(
+      event_type: AuditEmissionService::EVENT_OVERRIDE_REQUESTED,
+      action: "request",
+      target: override_request,
+      business_date: BusinessDateService.current,
+      metadata: {
+        request_type: override_request.request_type,
+        operational_transaction_id: override_request.operational_transaction_id
+      }.compact
+    )
+    override_request
   end
 
   def approve!
@@ -63,6 +75,7 @@ class OverrideRequestService
       status: OVERRIDE_STATUS_APPROVED,
       approved_by_id: @approved_by_id
     )
+    emit_override_event!(AuditEmissionService::EVENT_OVERRIDE_APPROVED, "approve")
     @override_request
   end
 
@@ -73,6 +86,7 @@ class OverrideRequestService
       status: OVERRIDE_STATUS_DENIED,
       approved_by_id: @approved_by_id
     )
+    emit_override_event!(AuditEmissionService::EVENT_OVERRIDE_DENIED, "deny")
     @override_request
   end
 
@@ -82,10 +96,24 @@ class OverrideRequestService
     raise OverrideError, "Override has expired" if expired?(@override_request)
 
     @override_request.update!(status: OVERRIDE_STATUS_USED, used_at: Time.current)
+    emit_override_event!(AuditEmissionService::EVENT_OVERRIDE_USED, "use")
     @override_request
   end
 
   private
+
+  def emit_override_event!(event_type, action)
+    AuditEmissionService.emit!(
+      event_type: event_type,
+      action: action,
+      target: @override_request,
+      business_date: BusinessDateService.current,
+      metadata: {
+        request_type: @override_request.request_type,
+        operational_transaction_id: @override_request.operational_transaction_id
+      }.compact
+    )
+  end
 
   def expired?(override_request)
     override_request.expires_at.present? && override_request.expires_at < Time.current

--- a/app/services/posting_engine.rb
+++ b/app/services/posting_engine.rb
@@ -36,6 +36,8 @@ class PostingEngine
     existing_batch = matching_idempotent_batch
     return existing_batch if existing_batch.present?
 
+    emit_posting_requested!
+
     ActiveRecord::Base.transaction do
       build_and_validate_legs!
       create_posted_records!
@@ -44,6 +46,9 @@ class PostingEngine
     existing_batch = matching_idempotent_batch
     return existing_batch if existing_batch.present?
 
+    raise
+  rescue StandardError => e
+    emit_posting_failed!(e)
     raise
   end
 
@@ -154,13 +159,14 @@ class PostingEngine
     AccountProjector.project!(posting_batch: batch)
 
     AuditEmissionService.emit!(
-      event_type: @reversal_of_batch_id ? "reversal_posted" : "posting_succeeded",
+      event_type: AuditEmissionService::EVENT_POSTING_COMMITTED,
       action: "post",
       target: batch,
       business_date: @business_date,
       metadata: {
         transaction_code: @transaction_code,
-        reversal_of_batch_id: @reversal_of_batch_id
+        reversal_of_batch_id: @reversal_of_batch_id,
+        posting_reference: batch.posting_reference
       }
     )
 
@@ -226,5 +232,28 @@ class PostingEngine
     else
       value
     end
+  end
+
+  def emit_posting_requested!
+    AuditEmissionService.emit!(
+      event_type: AuditEmissionService::EVENT_POSTING_REQUESTED,
+      action: "request",
+      business_date: @business_date,
+      metadata: semantic_idempotency_payload
+    )
+  end
+
+  def emit_posting_failed!(error)
+    AuditEmissionService.emit!(
+      event_type: AuditEmissionService::EVENT_POSTING_FAILED,
+      action: "fail",
+      business_date: @business_date,
+      metadata: semantic_idempotency_payload.merge(
+        error_class: error.class.name,
+        error_message: error.message
+      )
+    )
+  rescue StandardError
+    nil
   end
 end

--- a/app/services/reversal_service.rb
+++ b/app/services/reversal_service.rb
@@ -2,8 +2,10 @@
 
 class ReversalService
   include Bankcore::Enums
+  include ActiveSupport::NumberHelper
 
   class ReversalError < StandardError; end
+  class OverrideRequiredError < ReversalError; end
 
   def self.reverse!(posting_batch:, idempotency_key: nil, override_request: nil)
     new(posting_batch: posting_batch, idempotency_key: idempotency_key, override_request: override_request).reverse!
@@ -27,17 +29,21 @@ class ReversalService
     reversal_code = TransactionCode.find_by(code: @posting_batch.transaction_code)&.reversal_code
     raise ReversalError, "No reversal code for #{@posting_batch.transaction_code}" if reversal_code.blank?
 
+    override_request = resolve_override_request!
+    emit_reversal_requested!(reversal_code: reversal_code)
+
     reversal_batch = nil
     ActiveRecord::Base.transaction do
       reversal_batch = create_reversal_batch!(reversal_code)
-      OverrideRequestService.use!(override_request: @override_request) if @override_request.present?
+      OverrideRequestService.use!(override_request: override_request) if override_request.present?
       AuditEmissionService.emit!(
-        event_type: "reversal_created",
+        event_type: AuditEmissionService::EVENT_REVERSAL_COMMITTED,
         action: "reverse",
         target: reversal_batch,
         metadata: {
           original_batch_id: @posting_batch.id,
-          reversal_code: reversal_code
+          reversal_code: reversal_code,
+          posting_reference: reversal_batch.posting_reference
         }
       )
     end
@@ -66,5 +72,48 @@ class ReversalService
 
   def idempotent_replay?
     @idempotency_key.present? && @posting_batch.reversal_batch.idempotency_key == @idempotency_key
+  end
+
+  def resolve_override_request!
+    return nil unless override_required?
+
+    override_request = @override_request || OverrideRequest.usable.find_by(
+      operational_transaction_id: @posting_batch.operational_transaction_id,
+      request_type: OVERRIDE_TYPE_REVERSAL
+    )
+    raise OverrideRequiredError, override_required_message unless override_request
+
+    validate_override_request!(override_request)
+    override_request
+  end
+
+  def validate_override_request!(override_request)
+    return if override_request.request_type == OVERRIDE_TYPE_REVERSAL &&
+      override_request.operational_transaction_id == @posting_batch.operational_transaction_id
+
+    raise ReversalError, "Override request is not valid for this reversal"
+  end
+
+  def override_required?
+    @posting_batch.posting_legs.sum(:amount_cents) >= Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS
+  end
+
+  def override_required_message
+    threshold = number_to_currency(Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS / 100.0)
+    "Reversals of #{threshold} or more require supervisor approval. Please request an override first."
+  end
+
+  def emit_reversal_requested!(reversal_code:)
+    AuditEmissionService.emit!(
+      event_type: AuditEmissionService::EVENT_REVERSAL_REQUESTED,
+      action: "request",
+      target: @posting_batch,
+      business_date: BusinessDateService.current,
+      metadata: {
+        original_batch_id: @posting_batch.id,
+        reversal_code: reversal_code,
+        idempotency_key: @idempotency_key
+      }.compact
+    )
   end
 end

--- a/db/migrate/20260308194000_add_unique_index_to_posting_batches_posting_reference.rb
+++ b/db/migrate/20260308194000_add_unique_index_to_posting_batches_posting_reference.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToPostingBatchesPostingReference < ActiveRecord::Migration[8.1]
+  def change
+    add_index :posting_batches, :posting_reference, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_08_191000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_08_194000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -258,6 +258,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_08_191000) do
     t.datetime "updated_at", null: false
     t.index ["idempotency_key"], name: "index_posting_batches_on_idempotency_key", unique: true
     t.index ["operational_transaction_id"], name: "index_posting_batches_on_operational_transaction_id"
+    t.index ["posting_reference"], name: "index_posting_batches_on_posting_reference", unique: true
     t.index ["reversal_of_batch_id"], name: "index_posting_batches_on_reversal_of_batch_id"
   end
 

--- a/test/integration/posting_flow_test.rb
+++ b/test/integration/posting_flow_test.rb
@@ -14,7 +14,7 @@ class PostingFlowTest < ActiveSupport::TestCase
     batch = PostingEngine.post!(
       transaction_code: "ADJ_CREDIT",
       account_id: @account.id,
-      amount_cents: 10_000,
+      amount_cents: 4_000,
       business_date: @business_date
     )
 
@@ -30,7 +30,7 @@ class PostingFlowTest < ActiveSupport::TestCase
     @account.reload
     balance = @account.account_balances.first
     assert balance, "Account balance should exist"
-    assert_equal 10_000, balance.posted_balance_cents
+    assert_equal 4_000, balance.posted_balance_cents
 
     # 4. Reverse
     reversal_batch = ReversalService.reverse!(posting_batch: batch)

--- a/test/models/posted_record_immutability_test.rb
+++ b/test/models/posted_record_immutability_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PostedRecordImmutabilityTest < ActiveSupport::TestCase
+  def setup
+    @batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 4_200,
+      business_date: business_dates(:one).business_date
+    )
+    @posting_leg = @batch.posting_legs.first
+    @journal_entry = @batch.journal_entries.first
+    @journal_entry_line = @journal_entry.journal_entry_lines.first
+    @account_transaction = AccountTransaction.find_by!(posting_batch_id: @batch.id)
+  end
+
+  test "posted financial rows reject updates" do
+    assert_immutable_update(@batch, transaction_code: "ADJ_DEBIT")
+    assert_immutable_update(@posting_leg, amount_cents: 9_999)
+    assert_immutable_update(@journal_entry, reference_number: "JE-OVERRIDE")
+    assert_immutable_update(@journal_entry_line, memo: "updated")
+    assert_immutable_update(@account_transaction, description: "updated")
+  end
+
+  test "posted financial rows reject deletes" do
+    assert_immutable_destroy(@batch)
+    assert_immutable_destroy(@posting_leg)
+    assert_immutable_destroy(@journal_entry)
+    assert_immutable_destroy(@journal_entry_line)
+    assert_immutable_destroy(@account_transaction)
+  end
+
+  private
+
+  def assert_immutable_update(record, attrs)
+    assert_raises(ActiveRecord::RecordNotSaved) do
+      record.update!(attrs)
+    end
+
+    assert_includes record.errors.full_messages.join(", "), "cannot be updated once posted"
+  end
+
+  def assert_immutable_destroy(record)
+    assert_raises(ActiveRecord::RecordNotDestroyed) do
+      record.destroy!
+    end
+
+    assert_includes record.errors.full_messages.join(", "), "cannot be deleted once posted"
+  end
+end

--- a/test/services/audit_emission_service_test.rb
+++ b/test/services/audit_emission_service_test.rb
@@ -6,7 +6,7 @@ class AuditEmissionServiceTest < ActiveSupport::TestCase
   test "emit! creates audit event" do
     assert_difference "AuditEvent.count", 1 do
       AuditEmissionService.emit!(
-        event_type: "posting_succeeded",
+        event_type: "posting_committed",
         action: "post",
         target: posting_batches(:one),
         metadata: { transaction_code: "ADJ_CREDIT" }
@@ -14,7 +14,7 @@ class AuditEmissionServiceTest < ActiveSupport::TestCase
     end
 
     event = AuditEvent.last
-    assert_equal "posting_succeeded", event.event_type
+    assert_equal "posting_committed", event.event_type
     assert_equal "post", event.action
     assert_equal "PostingBatch", event.target_type
     assert event.target_id.present?
@@ -23,7 +23,7 @@ class AuditEmissionServiceTest < ActiveSupport::TestCase
 
   test "emit! with optional params" do
     AuditEmissionService.emit!(
-      event_type: "reversal_created",
+      event_type: "reversal_committed",
       action: "reverse",
       target: nil,
       actor: nil,
@@ -32,7 +32,7 @@ class AuditEmissionServiceTest < ActiveSupport::TestCase
     )
 
     event = AuditEvent.last
-    assert_equal "reversal_created", event.event_type
+    assert_equal "reversal_committed", event.event_type
     assert_equal Date.current, event.business_date
   end
 

--- a/test/services/business_date_eod_service_test.rb
+++ b/test/services/business_date_eod_service_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BusinessDateEodServiceTest < ActiveSupport::TestCase
+  test "run! closes current date, opens next date, and emits audit events" do
+    current_date = business_dates(:one).business_date
+    BankingTransaction.where(business_date: current_date, status: "draft").update_all(status: "posted", posted_at: Time.current)
+
+    assert_difference "AuditEvent.count", 2 do
+      assert BusinessDateEodService.run!
+    end
+
+    assert_equal "closed", BusinessDate.find_by!(business_date: current_date).status
+    assert_equal "open", BusinessDate.find_by!(business_date: current_date + 1).status
+    assert_equal [ "business_date_closed", "business_date_opened" ], AuditEvent.order(:id).last(2).map(&:event_type)
+  end
+end

--- a/test/services/fee_posting_service_test.rb
+++ b/test/services/fee_posting_service_test.rb
@@ -106,7 +106,32 @@ class FeePostingServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "rolls back posting when fee assessment linkage fails" do
+    assert_no_difference [ "BankingTransaction.count", "PostingBatch.count", "PostingLeg.count", "FeeAssessment.count" ] do
+      error = assert_raises(RuntimeError) do
+        with_stubbed_class_method(FeeAssessment, :find_or_create_by!, ->(*) { raise "fee linkage failed" }) do
+          FeePostingService.assess!(
+            account_id: @account.id,
+            fee_type_id: @fee_type.id,
+            amount_cents: 2500,
+            business_date: @business_date
+          )
+        end
+      end
+
+      assert_equal "fee linkage failed", error.message
+    end
+  end
+
   private
+
+  def with_stubbed_class_method(klass, method_name, replacement)
+    original = klass.method(method_name)
+    klass.define_singleton_method(method_name, &replacement)
+    yield
+  ensure
+    klass.define_singleton_method(method_name, original)
+  end
 
   def ensure_fee_post_template!
     return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "FEE_POST" })

--- a/test/services/interest_accrual_service_test.rb
+++ b/test/services/interest_accrual_service_test.rb
@@ -84,7 +84,31 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "rolls back posting when interest accrual linkage fails" do
+    assert_no_difference [ "BankingTransaction.count", "PostingBatch.count", "PostingLeg.count", "InterestAccrual.count" ] do
+      error = assert_raises(RuntimeError) do
+        with_stubbed_class_method(InterestAccrual, :find_or_create_by!, ->(*) { raise "accrual linkage failed" }) do
+          InterestAccrualService.accrue!(
+            account_id: @account.id,
+            amount_cents: 150,
+            accrual_date: @accrual_date
+          )
+        end
+      end
+
+      assert_equal "accrual linkage failed", error.message
+    end
+  end
+
   private
+
+  def with_stubbed_class_method(klass, method_name, replacement)
+    original = klass.method(method_name)
+    klass.define_singleton_method(method_name, &replacement)
+    yield
+  ensure
+    klass.define_singleton_method(method_name, original)
+  end
 
   def ensure_int_accrual_template!
     return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "INT_ACCRUAL" })

--- a/test/services/journal_projector_test.rb
+++ b/test/services/journal_projector_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class JournalProjectorTest < ActiveSupport::TestCase
+  test "uses posting reference as journal entry reference number" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 1_000,
+      business_date: business_dates(:one).business_date
+    )
+
+    assert_equal batch.posting_reference, batch.journal_entries.first.reference_number
+  end
+end

--- a/test/services/override_request_service_test.rb
+++ b/test/services/override_request_service_test.rb
@@ -10,17 +10,21 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
   end
 
   test "request! creates pending override" do
-    req = OverrideRequestService.request!(
-      request_type: "reversal",
-      requested_by_id: @user.id,
-      branch_id: @branch.id,
-      reason_text: "Correcting error"
-    )
+    req = nil
+    assert_difference "AuditEvent.count", 1 do
+      req = OverrideRequestService.request!(
+        request_type: "reversal",
+        requested_by_id: @user.id,
+        branch_id: @branch.id,
+        reason_text: "Correcting error"
+      )
+    end
 
     assert req.persisted?
     assert_equal "pending", req.status
     assert_equal "reversal", req.request_type
     assert_equal @user.id, req.requested_by_id
+    assert_equal "override_requested", AuditEvent.last.event_type
   end
 
   test "approve! updates status" do
@@ -30,11 +34,14 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
       branch_id: @branch.id
     )
 
-    OverrideRequestService.approve!(override_request: req, approved_by_id: @approver.id)
+    assert_difference "AuditEvent.count", 1 do
+      OverrideRequestService.approve!(override_request: req, approved_by_id: @approver.id)
+    end
 
     req.reload
     assert_equal "approved", req.status
     assert_equal @approver.id, req.approved_by_id
+    assert_equal "override_approved", AuditEvent.last.event_type
   end
 
   test "deny! updates status" do
@@ -44,10 +51,13 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
       branch_id: @branch.id
     )
 
-    OverrideRequestService.deny!(override_request: req, approved_by_id: @approver.id)
+    assert_difference "AuditEvent.count", 1 do
+      OverrideRequestService.deny!(override_request: req, approved_by_id: @approver.id)
+    end
 
     req.reload
     assert_equal "denied", req.status
+    assert_equal "override_denied", AuditEvent.last.event_type
   end
 
   test "use! marks override as used" do
@@ -58,11 +68,14 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
     )
     OverrideRequestService.approve!(override_request: req, approved_by_id: @approver.id)
 
-    OverrideRequestService.use!(override_request: req)
+    assert_difference "AuditEvent.count", 1 do
+      OverrideRequestService.use!(override_request: req)
+    end
 
     req.reload
     assert_equal "used", req.status
     assert req.used_at.present?
+    assert_equal "override_used", AuditEvent.last.event_type
   end
 
   test "approve! raises when not pending" do

--- a/test/services/posting_engine_test.rb
+++ b/test/services/posting_engine_test.rb
@@ -39,6 +39,25 @@ class PostingEngineTest < ActiveSupport::TestCase
     assert @account.account_transactions.any?
   end
 
+  test "assigns a unique posting reference to committed batches" do
+    batch1 = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: @account.id,
+      amount_cents: 1000,
+      business_date: @business_date
+    )
+    batch2 = PostingEngine.post!(
+      transaction_code: "ADJ_DEBIT",
+      account_id: @account.id,
+      amount_cents: 500,
+      business_date: @business_date
+    )
+
+    assert_match(/\APB-\d{8}-[A-F0-9]{12}\z/, batch1.posting_reference)
+    assert_match(/\APB-\d{8}-[A-F0-9]{12}\z/, batch2.posting_reference)
+    refute_equal batch1.posting_reference, batch2.posting_reference
+  end
+
   test "rejects unbalanced posting via validator" do
     # Template is balanced - validator would catch if legs were wrong
     # This tests that a valid posting works; invalid would need template manipulation
@@ -103,5 +122,61 @@ class PostingEngineTest < ActiveSupport::TestCase
         business_date: @business_date
       )
     end
+  end
+
+  test "rolls back posting when account projection fails" do
+    assert_no_difference [ "BankingTransaction.count", "PostingBatch.count", "PostingLeg.count", "JournalEntry.count", "JournalEntryLine.count", "AccountTransaction.count" ] do
+      error = assert_raises(RuntimeError) do
+        with_stubbed_class_method(AccountProjector, :project!, ->(*) { raise "projection exploded" }) do
+          PostingEngine.post!(
+            transaction_code: "ADJ_CREDIT",
+            account_id: @account.id,
+            amount_cents: 2500,
+            business_date: @business_date
+          )
+        end
+      end
+
+      assert_equal "projection exploded", error.message
+    end
+  end
+
+  test "emits posting requested and committed audit events" do
+    assert_difference "AuditEvent.count", 2 do
+      PostingEngine.post!(
+        transaction_code: "ADJ_CREDIT",
+        account_id: @account.id,
+        amount_cents: 1250,
+        business_date: @business_date
+      )
+    end
+
+    events = AuditEvent.order(:id).last(2)
+    assert_equal [ "posting_requested", "posting_committed" ], events.map(&:event_type)
+  end
+
+  test "emits posting failed audit event" do
+    assert_difference "AuditEvent.count", 2 do
+      assert_raises(PostingEngine::PostingError) do
+        PostingEngine.post!(
+          transaction_code: "INVALID_CODE",
+          account_id: @account.id,
+          amount_cents: 1000,
+          business_date: @business_date
+        )
+      end
+    end
+
+    assert_equal "posting_failed", AuditEvent.last.event_type
+  end
+
+  private
+
+  def with_stubbed_class_method(klass, method_name, replacement)
+    original = klass.method(method_name)
+    klass.define_singleton_method(method_name, &replacement)
+    yield
+  ensure
+    klass.define_singleton_method(method_name, original)
   end
 end

--- a/test/services/reversal_service_test.rb
+++ b/test/services/reversal_service_test.rb
@@ -9,7 +9,7 @@ class ReversalServiceTest < ActiveSupport::TestCase
     @batch = PostingEngine.post!(
       transaction_code: "ADJ_CREDIT",
       account_id: @account.id,
-      amount_cents: 7500,
+      amount_cents: 4000,
       business_date: @business_date
     )
   end
@@ -52,14 +52,15 @@ class ReversalServiceTest < ActiveSupport::TestCase
   end
 
   test "reverse! with override_request uses override" do
+    high_value_batch = high_value_batch()
     override = OverrideRequest.create!(
       request_type: "reversal",
       status: "approved",
-      operational_transaction_id: @batch.operational_transaction_id,
+      operational_transaction_id: high_value_batch.operational_transaction_id,
       branch_id: @account.branch_id
     )
 
-    reversal_batch = ReversalService.reverse!(posting_batch: @batch, override_request: override)
+    reversal_batch = ReversalService.reverse!(posting_batch: high_value_batch, override_request: override)
 
     assert reversal_batch.persisted?
     override.reload
@@ -74,5 +75,49 @@ class ReversalServiceTest < ActiveSupport::TestCase
     replay_batch = ReversalService.reverse!(posting_batch: @batch, idempotency_key: key)
 
     assert_equal reversal_batch.id, replay_batch.id
+  end
+
+  test "raises when high-value reversal lacks override approval" do
+    error = assert_raises(ReversalService::OverrideRequiredError) do
+      ReversalService.reverse!(posting_batch: high_value_batch())
+    end
+
+    assert_match(/require supervisor approval/i, error.message)
+  end
+
+  test "uses an existing approved override from service policy" do
+    high_value_batch = high_value_batch()
+    override = OverrideRequest.create!(
+      request_type: "reversal",
+      status: "approved",
+      operational_transaction_id: high_value_batch.operational_transaction_id,
+      branch_id: @account.branch_id
+    )
+
+    reversal_batch = ReversalService.reverse!(posting_batch: high_value_batch)
+
+    assert reversal_batch.persisted?
+    override.reload
+    assert_equal "used", override.status
+  end
+
+  test "emits reversal requested and committed audit events" do
+    assert_difference "AuditEvent.count", 4 do
+      ReversalService.reverse!(posting_batch: @batch)
+    end
+
+    events = AuditEvent.order(:id).last(4).map(&:event_type)
+    assert_equal [ "reversal_requested", "posting_requested", "posting_committed", "reversal_committed" ], events
+  end
+
+  private
+
+  def high_value_batch
+    PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: @account.id,
+      amount_cents: Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS,
+      business_date: @business_date
+    )
   end
 end


### PR DESCRIPTION
## Summary
- enforce immutability for posted financial rows and generate durable posting references on committed batches
- make fee and interest linkage creation atomic with posting, move reversal approval policy into services, and centralize override usage there
- expand posting lifecycle audit coverage and add regression tests for rollback, immutability, reversal policy, posting references, and business-date audit behavior

Closes #5.
Closes #7.
Closes #8.
Closes #9.
Closes #10.
Closes #11.

## Test plan
- [x] `bin/rubocop`
- [x] `bin/rails test`
- [x] `bin/ci`

## Data/migration impact
- adds a unique index on `posting_batches.posting_reference`
- updates `db/schema.rb`

## Financial logic risk
- medium
- this changes core posting, reversal, audit, and immutability behavior, but it is covered by targeted regression tests and full local CI

Made with [Cursor](https://cursor.com)