### PR TITLE
fix(reversal): use economic amount for override threshold

### DIFF
--- a/app/services/reversal_service.rb
+++ b/app/services/reversal_service.rb
@@ -95,7 +95,9 @@ class ReversalService
   end
 
   def override_required?
-    @posting_batch.posting_legs.sum(:amount_cents) >= Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS
+    # Use debit-leg sum (economic amount), not total leg sum which doubles for balanced two-leg postings
+    economic_amount_cents = @posting_batch.posting_legs.where(leg_type: LEG_TYPE_DEBIT).sum(:amount_cents)
+    economic_amount_cents >= Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS
   end
 
   def override_required_message

--- a/test/services/reversal_service_test.rb
+++ b/test/services/reversal_service_test.rb
@@ -85,6 +85,22 @@ class ReversalServiceTest < ActiveSupport::TestCase
     assert_match(/require supervisor approval/i, error.message)
   end
 
+  test "below-threshold reversal does not require override" do
+    # Economic amount (single leg) below threshold; sum of legs would incorrectly double it
+    below_threshold_cents = Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS / 2
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: @account.id,
+      amount_cents: below_threshold_cents,
+      business_date: @business_date
+    )
+
+    reversal_batch = ReversalService.reverse!(posting_batch: batch)
+
+    assert reversal_batch.persisted?
+    assert_equal "posted", reversal_batch.status
+  end
+
   test "uses an existing approved override from service policy" do
     high_value_batch = high_value_batch()
     override = OverrideRequest.create!(


### PR DESCRIPTION
## Summary
- `override_required?` now bases threshold on debit-leg sum (economic amount) instead of total leg sum
- Fixes incorrect doubling that forced override for reversals below policy threshold
- Adds test verifying below-threshold reversals do not require override

## Test plan
- [x] `bin/rails test test/services/reversal_service_test.rb` — 10 tests pass
- [x] `high_value_batch` and `below-threshold reversal does not require override` cover the fix

## Data / migration impact
- None

## Financial logic risk
- Low. Single comparison change; aligns override policy with actual transaction amount. Existing high-value tests still pass.

Closes #18

Made with [Cursor](https://cursor.com)