### PR TITLE
fix(reversal): prevent duplicate reversals via locking and unique index

### DIFF
--- a/app/services/reversal_service.rb
+++ b/app/services/reversal_service.rb
@@ -20,34 +20,36 @@ class ReversalService
   def reverse!
     raise ReversalError, "Batch is not posted" unless @posting_batch.status == STATUS_POSTED
 
-    if @posting_batch.reversal_batch.present?
-      return @posting_batch.reversal_batch if idempotent_replay?
+    @posting_batch.with_lock do
+      if @posting_batch.reversal_batch.present?
+        return @posting_batch.reversal_batch if idempotent_replay?
 
-      raise ReversalError, "Batch already reversed"
+        raise ReversalError, "Batch already reversed"
+      end
+
+      reversal_code = TransactionCode.find_by(code: @posting_batch.transaction_code)&.reversal_code
+      raise ReversalError, "No reversal code for #{@posting_batch.transaction_code}" if reversal_code.blank?
+
+      override_request = resolve_override_request!
+      emit_reversal_requested!(reversal_code: reversal_code)
+
+      reversal_batch = nil
+      ActiveRecord::Base.transaction do
+        reversal_batch = create_reversal_batch!(reversal_code)
+        OverrideRequestService.use!(override_request: override_request) if override_request.present?
+        AuditEmissionService.emit!(
+          event_type: AuditEmissionService::EVENT_REVERSAL_COMMITTED,
+          action: "reverse",
+          target: reversal_batch,
+          metadata: {
+            original_batch_id: @posting_batch.id,
+            reversal_code: reversal_code,
+            posting_reference: reversal_batch.posting_reference
+          }
+        )
+      end
+      reversal_batch
     end
-
-    reversal_code = TransactionCode.find_by(code: @posting_batch.transaction_code)&.reversal_code
-    raise ReversalError, "No reversal code for #{@posting_batch.transaction_code}" if reversal_code.blank?
-
-    override_request = resolve_override_request!
-    emit_reversal_requested!(reversal_code: reversal_code)
-
-    reversal_batch = nil
-    ActiveRecord::Base.transaction do
-      reversal_batch = create_reversal_batch!(reversal_code)
-      OverrideRequestService.use!(override_request: override_request) if override_request.present?
-      AuditEmissionService.emit!(
-        event_type: AuditEmissionService::EVENT_REVERSAL_COMMITTED,
-        action: "reverse",
-        target: reversal_batch,
-        metadata: {
-          original_batch_id: @posting_batch.id,
-          reversal_code: reversal_code,
-          posting_reference: reversal_batch.posting_reference
-        }
-      )
-    end
-    reversal_batch
   end
 
   private

--- a/db/migrate/20260309002855_add_unique_index_to_posting_batches_reversal_of_batch_id.rb
+++ b/db/migrate/20260309002855_add_unique_index_to_posting_batches_reversal_of_batch_id.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexToPostingBatchesReversalOfBatchId < ActiveRecord::Migration[8.1]
+  def change
+    remove_foreign_key :posting_batches, :posting_batches, column: :reversal_of_batch_id
+    remove_index :posting_batches, column: :reversal_of_batch_id, if_exists: true
+    add_index :posting_batches, :reversal_of_batch_id, unique: true
+    add_foreign_key :posting_batches, :posting_batches, column: :reversal_of_batch_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_08_194000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_002855) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -259,7 +259,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_08_194000) do
     t.index ["idempotency_key"], name: "index_posting_batches_on_idempotency_key", unique: true
     t.index ["operational_transaction_id"], name: "index_posting_batches_on_operational_transaction_id"
     t.index ["posting_reference"], name: "index_posting_batches_on_posting_reference", unique: true
-    t.index ["reversal_of_batch_id"], name: "index_posting_batches_on_reversal_of_batch_id"
+    t.index ["reversal_of_batch_id"], name: "index_posting_batches_on_reversal_of_batch_id", unique: true
   end
 
   create_table "posting_legs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|

--- a/test/services/reversal_service_test.rb
+++ b/test/services/reversal_service_test.rb
@@ -110,6 +110,34 @@ class ReversalServiceTest < ActiveSupport::TestCase
     assert_equal [ "reversal_requested", "posting_requested", "posting_committed", "reversal_committed" ], events
   end
 
+  test "concurrent reversal requests produce exactly one reversal batch" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: @account.id,
+      amount_cents: 4000,
+      business_date: @business_date
+    )
+
+    results = []
+    threads = 3.times.map do
+      Thread.new do
+        Thread.current[:result] = begin
+          ReversalService.reverse!(posting_batch: batch)
+        rescue ReversalService::ReversalError => e
+          e
+        end
+      end
+    end
+
+    threads.each(&:join)
+    reversal_batches = threads.map { |t| t[:result] }.select { |r| r.is_a?(PostingBatch) }
+    errors = threads.map { |t| t[:result] }.select { |r| r.is_a?(ReversalService::ReversalError) }
+
+    assert_equal 1, reversal_batches.size, "Exactly one thread should succeed with a reversal batch"
+    assert_equal 2, errors.size, "Other threads should get Batch already reversed"
+    assert_equal 1, PostingBatch.where(reversal_of_batch_id: batch.id).count
+  end
+
   private
 
   def high_value_batch


### PR DESCRIPTION
## Summary
- ReversalService#reverse! now uses with_lock on the original batch so the reversal_batch check and create run under SELECT FOR UPDATE
- Unique index on posting_batches.reversal_of_batch_id enforces one reversal per original batch at DB level
- Migration removes FK temporarily to replace non-unique index with unique index

## Test plan
- [x] `bin/rails test test/services/reversal_service_test.rb` — 10 tests pass including concurrency test
- [x] Concurrency test: 3 threads reverse same batch → exactly 1 reversal batch, 2 get Batch already reversed

## Data / migration impact
- Migration: removes FK, replaces index, re-adds FK. Run `bin/rails db:migrate`.

## Financial logic risk
- Medium. Prevents double-reversal which could zero balances incorrectly. Lock ensures serialization; unique index defense-in-depth.

Closes #20

Made with [Cursor](https://cursor.com)