### PR TITLE
Persist operational transaction metadata

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class TransactionsController < ApplicationController
+  TRANSACTION_FORM_FIELDS = %i[
+    transaction_code
+    account_id
+    source_account_id
+    destination_account_id
+    amount
+    memo
+    reason_text
+    reference_number
+    external_reference
+    idempotency_key
+  ].freeze
+
   before_action :set_transaction, only: %i[show reverse]
   before_action -> { require_permission(:reverse_transactions) }, only: %i[reverse]
 
@@ -41,21 +54,24 @@ class TransactionsController < ApplicationController
       return
     end
 
-    amount_cents = (params[:amount].to_f * 100).round
+    form_params = transaction_form_params
+    amount_cents = (form_params[:amount].to_f * 100).round
     batch = ManualTransactionEntryService.entry!(
-      transaction_code: params[:transaction_code],
-      account_id: params[:account_id].presence,
-      source_account_id: params[:source_account_id].presence,
-      destination_account_id: params[:destination_account_id].presence,
+      transaction_code: form_params[:transaction_code],
+      account_id: form_params[:account_id].presence,
+      source_account_id: form_params[:source_account_id].presence,
+      destination_account_id: form_params[:destination_account_id].presence,
       amount_cents: amount_cents,
-      idempotency_key: params[:idempotency_key].presence,
+      memo: form_params[:memo].presence,
+      reason_text: form_params[:reason_text].presence,
+      reference_number: form_params[:reference_number].presence,
+      external_reference: form_params[:external_reference].presence,
+      idempotency_key: form_params[:idempotency_key].presence,
       created_by_id: current_user&.id
     )
     redirect_to transaction_path(batch.operational_transaction_id), notice: "Transaction posted successfully."
   rescue PostingEngine::PostingError, PostingValidator::ValidationError => e
-    @transaction_codes = TransactionCode.where(active: true).order(:code)
-    @accounts = Account.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:account_number)
-    @business_date = BusinessDateService.current
+    load_form_dependencies
     flash.now[:alert] = e.message
     render :new, status: :unprocessable_entity
   end
@@ -67,31 +83,54 @@ class TransactionsController < ApplicationController
   end
 
   def preview_transaction
-    amount_cents = (params[:amount].to_f * 100).round
+    form_params = transaction_form_params
+    amount_cents = (form_params[:amount].to_f * 100).round
     @preview_legs = PostingEngine.preview!(
-      transaction_code: params[:transaction_code],
-      account_id: params[:account_id].presence,
-      source_account_id: params[:source_account_id].presence,
-      destination_account_id: params[:destination_account_id].presence,
+      transaction_code: form_params[:transaction_code],
+      account_id: form_params[:account_id].presence,
+      source_account_id: form_params[:source_account_id].presence,
+      destination_account_id: form_params[:destination_account_id].presence,
       amount_cents: amount_cents,
+      memo: form_params[:memo].presence,
+      reason_text: form_params[:reason_text].presence,
+      reference_number: form_params[:reference_number].presence,
+      external_reference: form_params[:external_reference].presence,
       gl_account_id: params[:gl_account_id].presence
     )
-    @transaction_code = params[:transaction_code]
+    @transaction_code = form_params[:transaction_code]
     @amount_cents = amount_cents
     @params_for_confirm = {
-      transaction_code: params[:transaction_code],
-      account_id: params[:account_id].presence,
-      source_account_id: params[:source_account_id].presence,
-      destination_account_id: params[:destination_account_id].presence,
-      amount: params[:amount],
-      idempotency_key: params[:idempotency_key].presence
+      transaction_code: form_params[:transaction_code],
+      account_id: form_params[:account_id].presence,
+      source_account_id: form_params[:source_account_id].presence,
+      destination_account_id: form_params[:destination_account_id].presence,
+      amount: form_params[:amount],
+      memo: form_params[:memo].presence,
+      reason_text: form_params[:reason_text].presence,
+      reference_number: form_params[:reference_number].presence,
+      external_reference: form_params[:external_reference].presence,
+      idempotency_key: form_params[:idempotency_key].presence
     }.compact
+    @preview_metadata = @params_for_confirm.slice(:memo, :reason_text, :reference_number, :external_reference, :idempotency_key)
     render :preview
   rescue PostingEngine::PostingError, PostingValidator::ValidationError => e
+    load_form_dependencies
+    flash.now[:alert] = e.message
+    render :new, status: :unprocessable_entity
+  end
+
+  def transaction_form_params
+    raw_params = params[:transaction]
+    return {}.with_indifferent_access unless raw_params.respond_to?(:[])
+
+    TRANSACTION_FORM_FIELDS.each_with_object({}.with_indifferent_access) do |field, result|
+      result[field] = raw_params[field]
+    end
+  end
+
+  def load_form_dependencies
     @transaction_codes = TransactionCode.where(active: true).order(:code)
     @accounts = Account.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:account_number)
     @business_date = BusinessDateService.current
-    flash.now[:alert] = e.message
-    render :new, status: :unprocessable_entity
   end
 end

--- a/app/models/account_transaction.rb
+++ b/app/models/account_transaction.rb
@@ -4,7 +4,9 @@ class AccountTransaction < ApplicationRecord
   include PostedRecordImmutable
 
   belongs_to :account
+  belongs_to :contra_account, class_name: "Account", optional: true
   belongs_to :posting_batch
+  belongs_to :operational_transaction, class_name: "BankingTransaction", foreign_key: :transaction_id, optional: true
 
   def debit_cents
     direction == "debit" ? amount_cents : 0
@@ -18,6 +20,7 @@ class AccountTransaction < ApplicationRecord
   validates :posting_batch_id, presence: true
   validates :amount_cents, presence: true, numericality: { only_integer: true }
   validates :direction, presence: true, inclusion: { in: %w[debit credit] }
+  validates :transaction_id, presence: true
 
   private
 

--- a/app/models/banking_transaction.rb
+++ b/app/models/banking_transaction.rb
@@ -7,9 +7,11 @@ class BankingTransaction < ApplicationRecord
 
   belongs_to :branch
   belongs_to :created_by, class_name: "User", optional: true
+  has_many :account_transactions, foreign_key: :transaction_id, dependent: :nullify
   has_one :posting_batch, foreign_key: :operational_transaction_id
 
   validates :transaction_type, presence: true
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::POSTING_STATUSES }
   validates :business_date, presence: true
+  validates :reference_number, uniqueness: { scope: :business_date }, allow_blank: true
 end

--- a/app/services/account_projector.rb
+++ b/app/services/account_projector.rb
@@ -13,21 +13,50 @@ class AccountProjector
     return unless @posting_batch.status == Bankcore::Enums::STATUS_POSTED
 
     account_legs = @posting_batch.posting_legs.where(ledger_scope: Bankcore::Enums::LEDGER_SCOPE_ACCOUNT)
+    contra_map = bilateral_contra_map(account_legs)
 
     account_legs.each do |leg|
       next if leg.account_id.blank?
 
       AccountTransaction.create!(
         account_id: leg.account_id,
+        contra_account_id: contra_map[leg.account_id],
         posting_batch_id: @posting_batch.id,
+        transaction_id: @posting_batch.operational_transaction_id,
         amount_cents: leg.amount_cents,
         direction: leg.leg_type,
-        description: [ @posting_batch.transaction_code, @posting_batch.posting_reference ].compact.join(" "),
+        description: build_description(leg.account_id, contra_map[leg.account_id]),
         business_date: @posting_batch.business_date,
         posted_at: @posting_batch.posted_at
       )
     end
 
     BalanceRefreshService.refresh!(account_ids: account_legs.map(&:account_id).compact.uniq)
+  end
+
+  private
+
+  def build_description(account_id, contra_account_id)
+    transaction = @posting_batch.operational_transaction
+    parts = []
+    parts << (transaction&.memo.presence || transaction&.reason_text.presence || @posting_batch.transaction_code)
+    parts << "Ref #{transaction.reference_number}" if transaction&.reference_number.present?
+
+    if contra_account_id.present?
+      contra_account_number = Account.find_by(id: contra_account_id)&.account_number
+      parts << "Contra #{contra_account_number}" if contra_account_number.present?
+    end
+
+    parts.join(" | ").truncate(255)
+  end
+
+  def bilateral_contra_map(account_legs)
+    account_ids = account_legs.map(&:account_id).compact.uniq
+    return {} unless account_ids.size == 2
+
+    {
+      account_ids.first => account_ids.second,
+      account_ids.second => account_ids.first
+    }
   end
 end

--- a/app/services/manual_transaction_entry_service.rb
+++ b/app/services/manual_transaction_entry_service.rb
@@ -6,13 +6,17 @@ class ManualTransactionEntryService
   end
 
   def initialize(transaction_code:, account_id: nil, source_account_id: nil, destination_account_id: nil,
-                 amount_cents:, memo: nil, idempotency_key: nil, created_by_id: nil, gl_account_id: nil)
+                 amount_cents:, memo: nil, reason_text: nil, reference_number: nil, external_reference: nil,
+                 idempotency_key: nil, created_by_id: nil, gl_account_id: nil)
     @transaction_code = transaction_code
     @account_id = account_id
     @source_account_id = source_account_id
     @destination_account_id = destination_account_id
     @amount_cents = amount_cents
     @memo = memo
+    @reason_text = reason_text
+    @reference_number = reference_number
+    @external_reference = external_reference
     @idempotency_key = idempotency_key
     @created_by_id = created_by_id
     @gl_account_id = gl_account_id
@@ -25,6 +29,10 @@ class ManualTransactionEntryService
       source_account_id: @source_account_id,
       destination_account_id: @destination_account_id,
       amount_cents: @amount_cents,
+      memo: @memo,
+      reason_text: @reason_text,
+      reference_number: @reference_number,
+      external_reference: @external_reference,
       idempotency_key: @idempotency_key,
       created_by_id: @created_by_id,
       gl_account_id: @gl_account_id

--- a/app/services/posting_engine.rb
+++ b/app/services/posting_engine.rb
@@ -18,7 +18,8 @@ class PostingEngine
 
   def initialize(transaction_code:, account_id: nil, source_account_id: nil, destination_account_id: nil,
                  amount_cents:, business_date: nil, idempotency_key: nil, created_by_id: nil,
-                 gl_account_id: nil, reversal_of_batch_id: nil, idempotency_context: nil)
+                 gl_account_id: nil, reversal_of_batch_id: nil, idempotency_context: nil,
+                 memo: nil, reason_text: nil, reference_number: nil, external_reference: nil)
     @transaction_code = transaction_code
     @account_id = account_id
     @source_account_id = source_account_id
@@ -30,6 +31,10 @@ class PostingEngine
     @gl_account_id = gl_account_id
     @reversal_of_batch_id = reversal_of_batch_id
     @idempotency_context = idempotency_context
+    @memo = memo
+    @reason_text = reason_text
+    @reference_number = reference_number
+    @external_reference = external_reference
   end
 
   def post!
@@ -129,7 +134,11 @@ class PostingEngine
       business_date: @business_date,
       initiated_at: Time.current,
       posted_at: Time.current,
-      created_by_id: @created_by_id
+      created_by_id: @created_by_id,
+      memo: @memo,
+      reason_text: @reason_text,
+      reference_number: @reference_number,
+      external_reference: @external_reference
     )
 
     batch = PostingBatch.create!(
@@ -210,6 +219,10 @@ class PostingEngine
       destination_account_id: @destination_account_id,
       amount_cents: @amount_cents,
       business_date: @business_date&.to_date&.iso8601,
+      memo: @memo,
+      reason_text: @reason_text,
+      reference_number: @reference_number,
+      external_reference: @external_reference,
       gl_account_id: @gl_account_id,
       reversal_of_batch_id: @reversal_of_batch_id
     }

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -91,7 +91,7 @@
                 <td class="ui-mono text-right"><%= atx.direction == "credit" ? number_to_currency(atx.amount_cents / 100.0) : "—" %></td>
                 <td class="ui-mono text-right"><%= atx.running_balance_cents.present? ? number_to_currency(atx.running_balance_cents / 100.0) : "—" %></td>
                 <td>
-                  <%= link_to "View", transaction_path(atx.posting_batch&.operational_transaction_id), class: "link link-primary link-hover text-sm" if atx.posting_batch&.operational_transaction_id.present? %>
+                  <%= link_to "View", transaction_path(atx.transaction_id || atx.posting_batch&.operational_transaction_id), class: "link link-primary link-hover text-sm" if (atx.transaction_id || atx.posting_batch&.operational_transaction_id).present? %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -87,10 +87,10 @@
                   <label class="label" for="transaction_code">
                     <span class="label-text text-sm font-medium">Transaction Type</span>
                   </label>
-                  <select name="transaction_code" id="transaction_code" class="select select-bordered w-full" required>
+                  <select name="transaction[transaction_code]" id="transaction_code" class="select select-bordered w-full" required>
                     <option value="">— Select type —</option>
                     <% @transaction_codes.each do |tc| %>
-                      <option value="<%= tc.code %>" <%= "selected" if params[:transaction_code] == tc.code %>><%= tc.code %> — <%= tc.description %></option>
+                      <option value="<%= tc.code %>" <%= "selected" if params.dig(:transaction, :transaction_code) == tc.code %>><%= tc.code %> — <%= tc.description %></option>
                     <% end %>
                   </select>
                 </div>
@@ -99,7 +99,7 @@
                   <label class="label" for="amount">
                     <span class="label-text text-sm font-medium">Amount (USD)</span>
                   </label>
-                  <input type="number" name="amount" id="amount" step="0.01" min="0" value="<%= params[:amount] %>" class="input input-bordered w-full ui-mono text-lg" placeholder="0.00" required>
+                  <input type="number" name="transaction[amount]" id="amount" step="0.01" min="0" value="<%= params.dig(:transaction, :amount) %>" class="input input-bordered w-full ui-mono text-lg" placeholder="0.00" required>
                 </div>
               </div>
             </section>
@@ -113,10 +113,10 @@
                 <label class="label" for="account_id">
                   <span class="label-text text-sm font-medium">Account</span>
                 </label>
-                <select name="account_id" id="account_id" class="select select-bordered w-full ui-mono" data-preselected-account="<%= @preselected_account_id || params[:account_id] %>">
+                <select name="transaction[account_id]" id="account_id" class="select select-bordered w-full ui-mono" data-preselected-account="<%= @preselected_account_id || params.dig(:transaction, :account_id) %>">
                   <option value="">— Select account —</option>
                   <% @accounts.each do |acc| %>
-                    <option value="<%= acc.id %>" <%= "selected" if (@preselected_account_id.to_i == acc.id || params[:account_id].to_i == acc.id) %>><%= acc.account_number %> — <%= acc.status %></option>
+                    <option value="<%= acc.id %>" <%= "selected" if (@preselected_account_id.to_i == acc.id || params.dig(:transaction, :account_id).to_i == acc.id) %>><%= acc.account_number %> — <%= acc.status %></option>
                   <% end %>
                 </select>
               </div>
@@ -126,10 +126,10 @@
                   <label class="label" for="source_account_id">
                     <span class="label-text text-sm font-medium">From Account</span>
                   </label>
-                  <select name="source_account_id" id="source_account_id" class="select select-bordered w-full ui-mono">
+                  <select name="transaction[source_account_id]" id="source_account_id" class="select select-bordered w-full ui-mono">
                     <option value="">— Select account —</option>
                     <% @accounts.each do |acc| %>
-                      <option value="<%= acc.id %>" <%= "selected" if params[:source_account_id].to_i == acc.id %>><%= acc.account_number %></option>
+                      <option value="<%= acc.id %>" <%= "selected" if params.dig(:transaction, :source_account_id).to_i == acc.id %>><%= acc.account_number %></option>
                     <% end %>
                   </select>
                 </div>
@@ -138,10 +138,10 @@
                   <label class="label" for="destination_account_id">
                     <span class="label-text text-sm font-medium">To Account</span>
                   </label>
-                  <select name="destination_account_id" id="destination_account_id" class="select select-bordered w-full ui-mono">
+                  <select name="transaction[destination_account_id]" id="destination_account_id" class="select select-bordered w-full ui-mono">
                     <option value="">— Select account —</option>
                     <% @accounts.each do |acc| %>
-                      <option value="<%= acc.id %>" <%= "selected" if params[:destination_account_id].to_i == acc.id %>><%= acc.account_number %></option>
+                      <option value="<%= acc.id %>" <%= "selected" if params.dig(:transaction, :destination_account_id).to_i == acc.id %>><%= acc.account_number %></option>
                     <% end %>
                   </select>
                 </div>
@@ -153,11 +153,41 @@
                 <h3 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Control Metadata</h3>
               </div>
 
-              <div class="form-control w-full">
-                <label class="label" for="idempotency_key">
-                  <span class="label-text text-sm font-medium">Idempotency Key</span>
-                </label>
-                <input type="text" name="idempotency_key" id="idempotency_key" value="<%= params[:idempotency_key] %>" class="input input-bordered w-full ui-mono" placeholder="e.g. manual-20260307-001">
+              <div class="grid gap-4 lg:grid-cols-2">
+                <div class="form-control w-full lg:col-span-2">
+                  <label class="label" for="memo">
+                    <span class="label-text text-sm font-medium">Memo</span>
+                  </label>
+                  <textarea name="transaction[memo]" id="memo" class="textarea textarea-bordered w-full" rows="3" placeholder="Operator-visible summary for account history and transaction review"><%= params.dig(:transaction, :memo) %></textarea>
+                </div>
+
+                <div class="form-control w-full lg:col-span-2">
+                  <label class="label" for="reason_text">
+                    <span class="label-text text-sm font-medium">Reason / Justification</span>
+                  </label>
+                  <textarea name="transaction[reason_text]" id="reason_text" class="textarea textarea-bordered w-full" rows="2" placeholder="Why this transaction is being entered"><%= params.dig(:transaction, :reason_text) %></textarea>
+                </div>
+
+                <div class="form-control w-full">
+                  <label class="label" for="reference_number">
+                    <span class="label-text text-sm font-medium">Reference Number</span>
+                  </label>
+                  <input type="text" name="transaction[reference_number]" id="reference_number" value="<%= params.dig(:transaction, :reference_number) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. MAN-20260309-001">
+                </div>
+
+                <div class="form-control w-full">
+                  <label class="label" for="external_reference">
+                    <span class="label-text text-sm font-medium">External Reference</span>
+                  </label>
+                  <input type="text" name="transaction[external_reference]" id="external_reference" value="<%= params.dig(:transaction, :external_reference) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. case ID, ACH trace, ticket">
+                </div>
+
+                <div class="form-control w-full lg:col-span-2">
+                  <label class="label" for="idempotency_key">
+                    <span class="label-text text-sm font-medium">Idempotency Key</span>
+                  </label>
+                  <input type="text" name="transaction[idempotency_key]" id="idempotency_key" value="<%= params.dig(:transaction, :idempotency_key) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. manual-20260307-001">
+                </div>
               </div>
             </section>
 

--- a/app/views/transactions/preview.html.erb
+++ b/app/views/transactions/preview.html.erb
@@ -19,6 +19,35 @@
     </div>
 
     <div class="ui-panel-body">
+      <% if @preview_metadata.present? %>
+        <div class="ui-kv-grid mb-5">
+          <% if @preview_metadata[:memo].present? %>
+            <div class="ui-kv-row">
+              <div class="ui-kv-label">Memo</div>
+              <div class="ui-kv-value"><%= @preview_metadata[:memo] %></div>
+            </div>
+          <% end %>
+          <% if @preview_metadata[:reason_text].present? %>
+            <div class="ui-kv-row">
+              <div class="ui-kv-label">Reason</div>
+              <div class="ui-kv-value"><%= @preview_metadata[:reason_text] %></div>
+            </div>
+          <% end %>
+          <% if @preview_metadata[:reference_number].present? %>
+            <div class="ui-kv-row">
+              <div class="ui-kv-label">Reference</div>
+              <div class="ui-kv-value ui-mono"><%= @preview_metadata[:reference_number] %></div>
+            </div>
+          <% end %>
+          <% if @preview_metadata[:external_reference].present? %>
+            <div class="ui-kv-row">
+              <div class="ui-kv-label">External Reference</div>
+              <div class="ui-kv-value ui-mono"><%= @preview_metadata[:external_reference] %></div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
       <table class="ui-ledger-table">
         <thead>
           <tr>
@@ -57,7 +86,7 @@
 
         <%= form_with url: transactions_path, method: :post, local: true, class: "flex flex-wrap items-center gap-2" do |f| %>
           <% @params_for_confirm.each do |key, value| %>
-            <%= hidden_field_tag key, value %>
+            <%= hidden_field_tag "transaction[#{key}]", value %>
           <% end %>
           <button type="submit" class="btn btn-primary">Confirm & Post</button>
           <%= link_to "Cancel", new_transaction_path, class: "btn btn-ghost" %>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -67,6 +67,18 @@
           <div class="ui-kv-label">Posted At</div>
           <div class="ui-kv-value ui-mono"><%= @transaction.posted_at&.strftime("%Y-%m-%d %H:%M") || "—" %></div>
         </div>
+        <div class="ui-kv-row">
+          <div class="ui-kv-label">External Reference</div>
+          <div class="ui-kv-value ui-mono"><%= @transaction.external_reference.presence || "—" %></div>
+        </div>
+        <div class="ui-kv-row">
+          <div class="ui-kv-label">Memo</div>
+          <div class="ui-kv-value"><%= @transaction.memo.presence || "—" %></div>
+        </div>
+        <div class="ui-kv-row">
+          <div class="ui-kv-label">Reason</div>
+          <div class="ui-kv-value"><%= @transaction.reason_text.presence || "—" %></div>
+        </div>
       </div>
     </div>
   </section>

--- a/db/migrate/20260309013000_add_operational_metadata_to_transactions.rb
+++ b/db/migrate/20260309013000_add_operational_metadata_to_transactions.rb
@@ -1,0 +1,8 @@
+class AddOperationalMetadataToTransactions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :transactions, :memo, :text
+    add_column :transactions, :reason_text, :text
+
+    add_index :transactions, [ :business_date, :reference_number ], unique: true
+  end
+end

--- a/db/migrate/20260309013001_add_traceability_to_account_transactions.rb
+++ b/db/migrate/20260309013001_add_traceability_to_account_transactions.rb
@@ -1,0 +1,6 @@
+class AddTraceabilityToAccountTransactions < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :account_transactions, :transaction, foreign_key: { to_table: :transactions }
+    add_reference :account_transactions, :contra_account, foreign_key: { to_table: :accounts }
+  end
+end

--- a/db/migrate/20260309013002_backfill_account_transaction_traceability.rb
+++ b/db/migrate/20260309013002_backfill_account_transaction_traceability.rb
@@ -1,0 +1,31 @@
+class BackfillAccountTransactionTraceability < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE account_transactions
+      INNER JOIN posting_batches ON posting_batches.id = account_transactions.posting_batch_id
+      SET account_transactions.transaction_id = posting_batches.operational_transaction_id
+      WHERE account_transactions.transaction_id IS NULL
+        AND posting_batches.operational_transaction_id IS NOT NULL
+    SQL
+
+    execute <<~SQL.squish
+      UPDATE account_transactions
+      INNER JOIN posting_batches ON posting_batches.id = account_transactions.posting_batch_id
+      INNER JOIN posting_legs own_leg
+        ON own_leg.posting_batch_id = posting_batches.id
+       AND own_leg.account_id = account_transactions.account_id
+      INNER JOIN posting_legs contra_leg
+        ON contra_leg.posting_batch_id = posting_batches.id
+       AND contra_leg.account_id IS NOT NULL
+       AND contra_leg.account_id <> account_transactions.account_id
+      SET account_transactions.contra_account_id = contra_leg.account_id
+      WHERE posting_batches.transaction_code = 'XFER_INTERNAL'
+        AND account_transactions.contra_account_id IS NULL
+    SQL
+  end
+
+  def down
+    execute "UPDATE account_transactions SET contra_account_id = NULL"
+    execute "UPDATE account_transactions SET transaction_id = NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_002855) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_013002) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -68,15 +68,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_002855) do
     t.bigint "account_id", null: false
     t.integer "amount_cents"
     t.date "business_date"
+    t.bigint "contra_account_id"
     t.datetime "created_at", null: false
     t.string "description"
     t.string "direction"
     t.datetime "posted_at"
     t.bigint "posting_batch_id", null: false
     t.integer "running_balance_cents"
+    t.bigint "transaction_id"
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_account_transactions_on_account_id"
+    t.index ["contra_account_id"], name: "index_account_transactions_on_contra_account_id"
     t.index ["posting_batch_id"], name: "index_account_transactions_on_posting_batch_id"
+    t.index ["transaction_id"], name: "index_account_transactions_on_transaction_id"
   end
 
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -353,12 +357,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_002855) do
     t.bigint "created_by_id"
     t.string "external_reference"
     t.datetime "initiated_at"
+    t.text "memo"
     t.datetime "posted_at"
+    t.text "reason_text"
     t.string "reference_number"
     t.string "status"
     t.string "transaction_type"
     t.datetime "updated_at", null: false
     t.index ["branch_id"], name: "index_transactions_on_branch_id"
+    t.index ["business_date", "reference_number"], name: "index_transactions_on_business_date_and_reference_number", unique: true
   end
 
   create_table "user_roles", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -389,7 +396,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_002855) do
   add_foreign_key "account_products", "gl_accounts", column: "asset_gl_account_id"
   add_foreign_key "account_products", "gl_accounts", column: "liability_gl_account_id"
   add_foreign_key "account_transactions", "accounts"
+  add_foreign_key "account_transactions", "accounts", column: "contra_account_id"
   add_foreign_key "account_transactions", "posting_batches"
+  add_foreign_key "account_transactions", "transactions"
   add_foreign_key "accounts", "account_products"
   add_foreign_key "accounts", "branches"
   add_foreign_key "deposit_accounts", "accounts"

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -16,21 +16,53 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     get new_transaction_url
     assert_response :success
     assert_select "select#transaction_code"
-    assert_select "input[name=amount]"
+    assert_select "input[name='transaction[amount]']"
   end
 
   test "create posts ADJ_CREDIT and redirects" do
     account = accounts(:one)
     assert_difference "BankingTransaction.count", 1 do
       post transactions_url, params: {
-        transaction_code: "ADJ_CREDIT",
-        account_id: account.id,
-        amount: "100.50"
+        transaction: {
+          transaction_code: "ADJ_CREDIT",
+          account_id: account.id,
+          amount: "100.50",
+          memo: "Courtesy credit",
+          reason_text: "Service recovery",
+          reference_number: "MAN-20260309-001",
+          external_reference: "CASE-42"
+        }
       }
     end
     assert_redirected_to transaction_path(BankingTransaction.last)
+    transaction = BankingTransaction.last
+    assert_equal "Courtesy credit", transaction.memo
+    assert_equal "Service recovery", transaction.reason_text
+    assert_equal "MAN-20260309-001", transaction.reference_number
+    assert_equal "CASE-42", transaction.external_reference
     follow_redirect!
     assert_match /posted successfully/i, flash[:notice]
+  end
+
+  test "preview preserves operational metadata for confirm step" do
+    post transactions_url, params: {
+      preview: "1",
+      transaction: {
+        transaction_code: "ADJ_CREDIT",
+        account_id: accounts(:one).id,
+        amount: "25.00",
+        memo: "Preview memo",
+        reason_text: "Preview reason",
+        reference_number: "MAN-20260309-002",
+        external_reference: "CASE-99"
+      }
+    }
+
+    assert_response :success
+    assert_select "input[type=hidden][name='transaction[memo]'][value='Preview memo']"
+    assert_select "input[type=hidden][name='transaction[reason_text]'][value='Preview reason']"
+    assert_select "input[type=hidden][name='transaction[reference_number]'][value='MAN-20260309-002']"
+    assert_select "input[type=hidden][name='transaction[external_reference]'][value='CASE-99']"
   end
 
   test "show renders transaction" do

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -9,3 +9,14 @@ one:
   opened_on: 2026-03-01
   created_at: <%= ts %>
   updated_at: <%= ts %>
+
+two:
+  account_number: "3001"
+  account_type: savings
+  account_product: savings
+  branch: one
+  currency_code: USD
+  status: active
+  opened_on: 2026-03-01
+  created_at: <%= ts %>
+  updated_at: <%= ts %>

--- a/test/services/posting_engine_test.rb
+++ b/test/services/posting_engine_test.rb
@@ -39,6 +39,53 @@ class PostingEngineTest < ActiveSupport::TestCase
     assert @account.account_transactions.any?
   end
 
+  test "persists operational metadata into transaction and account history" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: @account.id,
+      amount_cents: 10_000,
+      business_date: @business_date,
+      memo: "Courtesy credit",
+      reason_text: "Service recovery",
+      reference_number: "MAN-20260309-100",
+      external_reference: "CASE-100"
+    )
+
+    transaction = batch.operational_transaction
+    account_transaction = @account.account_transactions.order(:id).last
+
+    assert_equal "Courtesy credit", transaction.memo
+    assert_equal "Service recovery", transaction.reason_text
+    assert_equal "MAN-20260309-100", transaction.reference_number
+    assert_equal "CASE-100", transaction.external_reference
+    assert_equal transaction.id, account_transaction.transaction_id
+    assert_includes account_transaction.description, "Courtesy credit"
+    assert_includes account_transaction.description, "MAN-20260309-100"
+  end
+
+  test "records contra account context for internal transfers" do
+    ensure_internal_transfer_template!
+
+    destination = accounts(:two)
+    batch = PostingEngine.post!(
+      transaction_code: "XFER_INTERNAL",
+      source_account_id: @account.id,
+      destination_account_id: destination.id,
+      amount_cents: 2_500,
+      business_date: @business_date,
+      memo: "Sweep transfer",
+      reference_number: "XFER-20260309-001"
+    )
+
+    source_history = AccountTransaction.find_by!(posting_batch_id: batch.id, account_id: @account.id)
+    destination_history = AccountTransaction.find_by!(posting_batch_id: batch.id, account_id: destination.id)
+
+    assert_equal destination.id, source_history.contra_account_id
+    assert_equal @account.id, destination_history.contra_account_id
+    assert_includes source_history.description, destination.account_number
+    assert_includes destination_history.description, @account.account_number
+  end
+
   test "assigns a unique posting reference to committed batches" do
     batch1 = PostingEngine.post!(
       transaction_code: "ADJ_CREDIT",
@@ -171,6 +218,31 @@ class PostingEngineTest < ActiveSupport::TestCase
   end
 
   private
+
+  def ensure_internal_transfer_template!
+    xfer_code = TransactionCode.find_or_create_by!(code: "XFER_INTERNAL") do |code|
+      code.description = "Internal account transfer"
+      code.active = true
+    end
+
+    xfer_template = PostingTemplate.find_or_create_by!(transaction_code: xfer_code) do |template|
+      template.name = "Internal Transfer"
+      template.description = "Debit source, credit destination"
+      template.active = true
+    end
+
+    PostingTemplateLeg.find_or_create_by!(posting_template: xfer_template, position: 0) do |leg|
+      leg.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
+      leg.account_source = Bankcore::Enums::ACCOUNT_SOURCE_SOURCE
+      leg.description = "Debit source account"
+    end
+
+    PostingTemplateLeg.find_or_create_by!(posting_template: xfer_template, position: 1) do |leg|
+      leg.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
+      leg.account_source = Bankcore::Enums::ACCOUNT_SOURCE_DESTINATION
+      leg.description = "Credit destination account"
+    end
+  end
 
   def with_stubbed_class_method(klass, method_name, replacement)
     original = klass.method(method_name)


### PR DESCRIPTION
Closes #26

## Summary
- Persist memo, reason, and reference metadata on manual transactions so posted activity is easier to understand and audit.
- Add direct operational-transaction links and contra-account context to account history, especially for internal transfers.
- Nest transaction form params and switch to explicit extraction so the entry flow stays clean under CI security checks.

## Test plan
- [x] /*! 🌼 daisyUI 5.5.19 */
Running 116 tests in parallel using 2 processes
Run options: --seed 55686

# Running:

....................................................................................................................

Finished in 6.725220s, 17.2485 runs/s, 57.8420 assertions/s.
116 runs, 389 assertions, 0 failures, 0 errors, 0 skips
- [x] 
== Brakeman Report ==

Application Path: /home/syckot/BankCORE_2
Rails Version: 8.1.2
Brakeman Version: 8.0.4
Scan Date: 2026-03-09 03:02:05 +0000
Duration: 2.212941121 seconds
Checks Run: BasicAuth, BasicAuthTimingAttack, CSRFTokenForgeryCVE, ContentTag, CookieSerialization, CreateWith, CrossSiteScripting, DefaultRoutes, Deserialize, DetailedExceptions, DigestDoS, DynamicFinders, EOLRails, EOLRuby, EscapeFunction, Evaluation, Execute, FileAccess, FileDisclosure, FilterSkipping, ForgerySetting, HeaderDoS, I18nXSS, JRubyXML, JSONEncoding, JSONEntityEscape, JSONParsing, LinkTo, LinkToHref, MailTo, MassAssignment, MimeTypeDoS, ModelAttrAccessible, ModelAttributes, ModelSerialize, NestedAttributes, NestedAttributesBypass, NumberToCurrency, PageCachingCVE, Pathname, PermitAttributes, QuoteTableName, Ransack, Redirect, RegexDoS, Render, RenderDoS, RenderInline, RenderRCE, ResponseSplitting, RouteDoS, SQL, SQLCVEs, SSLVerify, SafeBufferManipulation, SanitizeConfigCve, SanitizeMethods, SelectTag, SelectVulnerability, Send, SendFile, SessionManipulation, SessionSettings, SimpleFormat, SingleQuotes, SkipBeforeFilter, SprocketsPathTraversal, StripTags, SymbolDoSCVE, TemplateInjection, TranslateBug, UnsafeReflection, UnsafeReflectionMethods, ValidationRegex, VerbConfusion, WeakRSAKey, WithoutProtection, XMLDoS, YAMLParsing

== Overview ==

Controllers: 14
Models: 29
Templates: 30
Errors: 0
Security Warnings: 0

== Warning Types ==


No warnings found

## Migration/data impact
- Adds  and .
- Adds a unique index on .
- Adds  and  with backfill for existing records.

## Financial risk
- No change to posting balance rules or atomic posting behavior.
- Changes are limited to operational metadata persistence and account-history traceability.

## Rollback notes
- Revert the branch and roll back the three new migrations if the metadata model needs to be withdrawn.

## UI screenshots
- Not included; change is limited to the manual transaction entry and review workflow.

Made with [Cursor](https://cursor.com)