### PR TITLE
Add Phase 2 product defaults

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -22,7 +22,6 @@ class AccountsController < ApplicationController
   def new
     @account = Account.new(
       status: Bankcore::Enums::STATUS_ACTIVE,
-      currency_code: "USD",
       opened_on: Date.current
     )
     set_form_options
@@ -52,16 +51,18 @@ class AccountsController < ApplicationController
   end
 
   def account_params
-    params.require(:account).permit(:account_number, :account_product_id, :branch_id, :currency_code)
+    params.require(:account).permit(:account_number, :account_product_id, :branch_id)
   end
 
   def create_deposit_account_if_needed!
-    return unless %w[dda now savings cd].include?(@account.account_type)
+    product = @account.account_product
+    return unless product&.deposit_product?
 
     DepositAccount.create!(
       account_id: @account.id,
-      deposit_type: @account.account_type,
-      interest_bearing: false
+      deposit_type: product.default_deposit_type,
+      interest_bearing: product.default_interest_bearing?,
+      overdraft_policy: product.default_overdraft_policy
     )
   end
 
@@ -88,6 +89,6 @@ class AccountsController < ApplicationController
     return if @account.account_product.blank?
 
     @account.account_type = @account.account_product.product_code
-    @account.currency_code = @account.account_product.currency_code if @account.currency_code.blank?
+    @account.currency_code = @account.account_product.currency_code
   end
 end

--- a/app/models/account_product.rb
+++ b/app/models/account_product.rb
@@ -3,6 +3,10 @@
 class AccountProduct < ApplicationRecord
   include Bankcore::Enums
 
+  STATEMENT_CYCLES = %w[monthly quarterly annual].freeze
+  DEPOSIT_PRODUCT_CODES = %w[dda now savings cd].freeze
+  INTEREST_BEARING_PRODUCT_CODES = %w[now savings cd].freeze
+
   belongs_to :liability_gl_account, class_name: "GlAccount", optional: true
   belongs_to :asset_gl_account, class_name: "GlAccount", optional: true
 
@@ -12,5 +16,24 @@ class AccountProduct < ApplicationRecord
   validates :name, presence: true
   validates :product_family, presence: true
   validates :currency_code, presence: true
+  validates :statement_cycle, presence: true, inclusion: { in: STATEMENT_CYCLES }
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::STATUSES }
+
+  def deposit_product?
+    product_family == "deposit" && DEPOSIT_PRODUCT_CODES.include?(product_code)
+  end
+
+  def default_deposit_type
+    product_code if deposit_product?
+  end
+
+  def default_interest_bearing?
+    INTEREST_BEARING_PRODUCT_CODES.include?(product_code)
+  end
+
+  def default_overdraft_policy
+    return nil unless deposit_product?
+
+    allow_overdraft ? "allow" : "disallow"
+  end
 end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -37,13 +37,6 @@
   </div>
 
   <div class="form-control w-full">
-    <label class="label" for="account_currency_code">
-      <span class="label-text">Currency</span>
-    </label>
-    <%= f.text_field :currency_code, class: "input input-bordered w-full", placeholder: "USD", required: true %>
-  </div>
-
-  <div class="form-control w-full">
     <label class="label" for="account_primary_party_id">
       <span class="label-text">Primary Owner (optional)</span>
     </label>
@@ -52,7 +45,7 @@
         { include_blank: "— None —" },
         class: "select select-bordered w-full" %>
     <label class="label">
-      <span class="label-text-alt">Add an owner later from the account page if needed</span>
+      <span class="label-text-alt">Currency, deposit defaults, and overdraft behavior come from the selected product</span>
     </label>
   </div>
 

--- a/db/migrate/20260309031500_add_phase2_fields_to_account_products.rb
+++ b/db/migrate/20260309031500_add_phase2_fields_to_account_products.rb
@@ -1,0 +1,6 @@
+class AddPhase2FieldsToAccountProducts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :account_products, :statement_cycle, :string, null: false, default: "monthly"
+    add_column :account_products, :allow_overdraft, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_013002) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_031500) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -50,6 +50,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_013002) do
   end
 
   create_table "account_products", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.boolean "allow_overdraft", default: false, null: false
     t.bigint "asset_gl_account_id"
     t.datetime "created_at", null: false
     t.string "currency_code", default: "USD", null: false
@@ -57,6 +58,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_013002) do
     t.string "name", null: false
     t.string "product_code", null: false
     t.string "product_family", null: false
+    t.string "statement_cycle", default: "monthly", null: false
     t.string "status", default: "active", null: false
     t.datetime "updated_at", null: false
     t.index ["asset_gl_account_id"], name: "index_account_products_on_asset_gl_account_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,22 +53,57 @@ end
 
 # 3. Account Products
 account_products_data = [
-  { product_code: "dda", name: "Noninterest-Bearing DDA", product_family: "deposit", currency_code: "USD", liability_gl_number: "2110" },
-  { product_code: "now", name: "Interest-Bearing Demand", product_family: "deposit", currency_code: "USD", liability_gl_number: "2120" },
-  { product_code: "savings", name: "Savings", product_family: "deposit", currency_code: "USD", liability_gl_number: "2130" },
-  { product_code: "cd", name: "Time Deposit", product_family: "deposit", currency_code: "USD", liability_gl_number: "2130" }
+  {
+    product_code: "dda",
+    name: "Noninterest-Bearing DDA",
+    product_family: "deposit",
+    currency_code: "USD",
+    statement_cycle: "monthly",
+    allow_overdraft: true,
+    liability_gl_number: "2110"
+  },
+  {
+    product_code: "now",
+    name: "Interest-Bearing Demand",
+    product_family: "deposit",
+    currency_code: "USD",
+    statement_cycle: "monthly",
+    allow_overdraft: true,
+    liability_gl_number: "2120"
+  },
+  {
+    product_code: "savings",
+    name: "Savings",
+    product_family: "deposit",
+    currency_code: "USD",
+    statement_cycle: "monthly",
+    allow_overdraft: false,
+    liability_gl_number: "2130"
+  },
+  {
+    product_code: "cd",
+    name: "Time Deposit",
+    product_family: "deposit",
+    currency_code: "USD",
+    statement_cycle: "monthly",
+    allow_overdraft: false,
+    liability_gl_number: "2130"
+  }
 ]
 
 account_products_data.each do |attrs|
   liability_gl = GlAccount.find_by!(gl_number: attrs.delete(:liability_gl_number))
-
-  AccountProduct.find_or_create_by!(product_code: attrs[:product_code]) do |product|
-    product.name = attrs[:name]
-    product.product_family = attrs[:product_family]
-    product.currency_code = attrs[:currency_code]
-    product.status = Bankcore::Enums::STATUS_ACTIVE
-    product.liability_gl_account = liability_gl
-  end
+  product = AccountProduct.find_or_initialize_by(product_code: attrs[:product_code])
+  product.assign_attributes(
+    name: attrs[:name],
+    product_family: attrs[:product_family],
+    currency_code: attrs[:currency_code],
+    statement_cycle: attrs[:statement_cycle],
+    allow_overdraft: attrs[:allow_overdraft],
+    status: Bankcore::Enums::STATUS_ACTIVE,
+    liability_gl_account: liability_gl
+  )
+  product.save!
 end
 
 # 4. Business Date
@@ -102,10 +137,14 @@ AccountOwner.find_or_create_by!(account_id: account.id, party_id: party.id) do |
   ao.effective_on = Date.current
 end
 
-DepositAccount.find_or_create_by!(account_id: account.id) do |da|
-  da.deposit_type = "dda"
-  da.interest_bearing = false
-end
+product = account.account_product
+deposit_account = DepositAccount.find_or_initialize_by(account_id: account.id)
+deposit_account.assign_attributes(
+  deposit_type: product.default_deposit_type,
+  interest_bearing: product.default_interest_bearing?,
+  overdraft_policy: product.default_overdraft_policy
+)
+deposit_account.save!
 
 # 6. Transaction Codes
 transaction_codes_data = [
@@ -396,10 +435,14 @@ AccountOwner.find_or_create_by!(account_id: account2.id, party_id: party.id) do 
   ao.effective_on = Date.current
 end
 
-DepositAccount.find_or_create_by!(account_id: account2.id) do |da|
-  da.deposit_type = "savings"
-  da.interest_bearing = true
-end
+product = account2.account_product
+deposit_account = DepositAccount.find_or_initialize_by(account_id: account2.id)
+deposit_account.assign_attributes(
+  deposit_type: product.default_deposit_type,
+  interest_bearing: product.default_interest_bearing?,
+  overdraft_policy: product.default_overdraft_policy
+)
+deposit_account.save!
 
 # 8. Fee Types (Phase 5)
 if defined?(FeeType)

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -17,9 +17,10 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='account[account_number]']"
     assert_select "select[name='account[account_product_id]']"
     assert_select "select[name='account[branch_id]']"
+    assert_select "input[name='account[currency_code]']", count: 0
   end
 
-  test "create creates account and redirects" do
+  test "create creates account with product-driven deposit defaults and redirects" do
     branch = branches(:one)
     product = account_products(:dda)
     assert_difference "Account.count", 1 do
@@ -27,8 +28,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
         account: {
           account_number: "2001",
           account_product_id: product.id,
-          branch_id: branch.id,
-          currency_code: "USD"
+          branch_id: branch.id
         }
       }
     end
@@ -37,8 +37,31 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2001", account.account_number
     assert_equal product.id, account.account_product_id
     assert_equal "dda", account.account_type
+    assert_equal "USD", account.currency_code
     assert_equal branch.id, account.branch_id
-    assert_not_nil account.deposit_account
+    assert_equal "dda", account.deposit_account.deposit_type
+    assert_equal false, account.deposit_account.interest_bearing
+    assert_equal "allow", account.deposit_account.overdraft_policy
+  end
+
+  test "create uses product defaults for interest-bearing deposit products" do
+    branch = branches(:one)
+    product = account_products(:now)
+
+    assert_difference "Account.count", 1 do
+      post accounts_url, params: {
+        account: {
+          account_number: "2003",
+          account_product_id: product.id,
+          branch_id: branch.id
+        }
+      }
+    end
+
+    account = Account.last
+    assert_equal "now", account.deposit_account.deposit_type
+    assert_equal true, account.deposit_account.interest_bearing
+    assert_equal "allow", account.deposit_account.overdraft_policy
   end
 
   test "create with primary party creates account owner" do
@@ -51,7 +74,6 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
           account_number: "2002",
           account_product_id: product.id,
           branch_id: branch.id,
-          currency_code: "USD",
           primary_party_id: party.id
         }
       }
@@ -68,8 +90,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       account: {
         account_number: "1001",
         account_product_id: product.id,
-        branch_id: branch.id,
-        currency_code: "USD"
+        branch_id: branch.id
       }
     }
     assert_response :unprocessable_entity

--- a/test/fixtures/account_products.yml
+++ b/test/fixtures/account_products.yml
@@ -4,6 +4,8 @@ dda:
   name: Noninterest-Bearing DDA
   product_family: deposit
   currency_code: USD
+  statement_cycle: monthly
+  allow_overdraft: true
   status: active
   liability_gl_account: six
   created_at: <%= ts %>
@@ -14,6 +16,8 @@ now:
   name: Interest-Bearing Demand
   product_family: deposit
   currency_code: USD
+  statement_cycle: monthly
+  allow_overdraft: true
   status: active
   liability_gl_account: seven
   created_at: <%= ts %>
@@ -24,6 +28,8 @@ savings:
   name: Savings
   product_family: deposit
   currency_code: USD
+  statement_cycle: monthly
+  allow_overdraft: false
   status: active
   liability_gl_account: eight
   created_at: <%= ts %>

--- a/test/models/account_product_test.rb
+++ b/test/models/account_product_test.rb
@@ -4,7 +4,14 @@ require "test_helper"
 
 class AccountProductTest < ActiveSupport::TestCase
   test "validates product_code presence and uniqueness" do
-    product = AccountProduct.new(name: "Test Product", product_family: "deposit", currency_code: "USD", status: "active")
+    product = AccountProduct.new(
+      name: "Test Product",
+      product_family: "deposit",
+      currency_code: "USD",
+      statement_cycle: "monthly",
+      allow_overdraft: false,
+      status: "active"
+    )
     assert_not product.valid?
     assert_includes product.errors[:product_code], "can't be blank"
 
@@ -13,8 +20,29 @@ class AccountProductTest < ActiveSupport::TestCase
       name: "Duplicate",
       product_family: "deposit",
       currency_code: "USD",
+      statement_cycle: "monthly",
+      allow_overdraft: false,
       status: "active"
     )
     assert_not duplicate.valid?
+  end
+
+  test "derives deposit defaults from product code" do
+    assert_equal "dda", account_products(:dda).default_deposit_type
+    assert_not account_products(:dda).default_interest_bearing?
+    assert_equal "allow", account_products(:dda).default_overdraft_policy
+
+    assert_equal "savings", account_products(:savings).default_deposit_type
+    assert account_products(:savings).default_interest_bearing?
+    assert_equal "disallow", account_products(:savings).default_overdraft_policy
+  end
+
+  test "validates statement_cycle inclusion" do
+    product = account_products(:dda).dup
+    product.product_code = "dda_invalid_cycle"
+    product.statement_cycle = "weekly"
+
+    assert_not product.valid?
+    assert_includes product.errors[:statement_cycle], "is not included in the list"
   end
 end


### PR DESCRIPTION
Closes #28

## Summary
- Add the Phase 2 account product fields for statement cycle and overdraft defaults so products can own more operational behavior.
- Make account creation derive currency, deposit type, interest-bearing behavior, and overdraft policy from the selected product instead of hardcoded account-type rules.
- Update seeds, fixtures, and tests so the product catalog and account creation path reflect the new product-driven defaults.

## Test plan
- [x] bin/rails test test/models/account_product_test.rb test/controllers/accounts_controller_test.rb
- [x] bin/rails test

## Migration/data impact
- Adds statement_cycle and allow_overdraft to account_products.
- Updates schema-backed product defaults and seed data for existing deposit products.

## Financial risk
- No change to posting balance logic, GL routing, or posting invariants.
- Scope is limited to product configuration defaults and account/deposit creation behavior.

## Rollback notes
- Revert the branch and roll back the Phase 2 account_products migration if the new product-default model needs to be withdrawn.

## UI screenshots
- Not included; the only UI change is removing manual currency entry from account creation because it now comes from the selected product.

Made with [Cursor](https://cursor.com)