### PR TITLE
Add product-aware interest routing

### DIFF
--- a/app/models/account_product.rb
+++ b/app/models/account_product.rb
@@ -9,6 +9,7 @@ class AccountProduct < ApplicationRecord
 
   belongs_to :liability_gl_account, class_name: "GlAccount", optional: true
   belongs_to :asset_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :interest_expense_gl_account, class_name: "GlAccount", optional: true
 
   has_many :accounts, dependent: :restrict_with_error
 
@@ -18,6 +19,7 @@ class AccountProduct < ApplicationRecord
   validates :currency_code, presence: true
   validates :statement_cycle, presence: true, inclusion: { in: STATEMENT_CYCLES }
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::STATUSES }
+  validate :interest_bearing_products_require_interest_expense_gl
 
   def deposit_product?
     product_family == "deposit" && DEPOSIT_PRODUCT_CODES.include?(product_code)
@@ -35,5 +37,18 @@ class AccountProduct < ApplicationRecord
     return nil unless deposit_product?
 
     allow_overdraft ? "allow" : "disallow"
+  end
+
+  def resolved_interest_expense_gl_account
+    interest_expense_gl_account
+  end
+
+  private
+
+  def interest_bearing_products_require_interest_expense_gl
+    return unless deposit_product? && default_interest_bearing?
+    return if interest_expense_gl_account.present?
+
+    errors.add(:interest_expense_gl_account, "must be present for interest-bearing products")
   end
 end

--- a/app/services/interest_accrual_service.rb
+++ b/app/services/interest_accrual_service.rb
@@ -19,11 +19,14 @@ class InterestAccrualService
     raise ArgumentError, "Amount must be non-negative" if @amount_cents.to_i < 0
 
     ActiveRecord::Base.transaction do
+      expense_gl_account = resolve_interest_expense_gl_account!
+
       batch = PostingEngine.post!(
         transaction_code: "INT_ACCRUAL",
-        account_id: nil,
+        account_id: @account_id,
         amount_cents: @amount_cents,
         business_date: @accrual_date,
+        gl_account_id: expense_gl_account.id,
         idempotency_key: @idempotency_key,
         idempotency_context: {
           service: "interest_accrual",
@@ -40,5 +43,15 @@ class InterestAccrualService
 
       batch
     end
+  end
+
+  private
+
+  def resolve_interest_expense_gl_account!
+    account = Account.includes(:account_product).find(@account_id)
+    gl_account = account.account_product&.resolved_interest_expense_gl_account
+    raise ArgumentError, "No interest expense GL configured for account product" unless gl_account
+
+    gl_account
   end
 end

--- a/db/migrate/20260309040000_add_interest_expense_gl_to_account_products.rb
+++ b/db/migrate/20260309040000_add_interest_expense_gl_to_account_products.rb
@@ -1,0 +1,22 @@
+class AddInterestExpenseGlToAccountProducts < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :account_products, :interest_expense_gl_account, foreign_key: { to_table: :gl_accounts }
+
+    execute <<~SQL.squish
+      UPDATE account_products
+      INNER JOIN gl_accounts ON gl_accounts.gl_number = CASE account_products.product_code
+        WHEN 'now' THEN '5120'
+        WHEN 'savings' THEN '5130'
+        WHEN 'cd' THEN '5130'
+        ELSE NULL
+      END
+      SET account_products.interest_expense_gl_account_id = gl_accounts.id
+      WHERE account_products.interest_expense_gl_account_id IS NULL
+        AND account_products.product_code IN ('now', 'savings', 'cd')
+    SQL
+  end
+
+  def down
+    remove_reference :account_products, :interest_expense_gl_account, foreign_key: { to_table: :gl_accounts }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_031500) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_040000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_031500) do
     t.bigint "asset_gl_account_id"
     t.datetime "created_at", null: false
     t.string "currency_code", default: "USD", null: false
+    t.bigint "interest_expense_gl_account_id"
     t.bigint "liability_gl_account_id"
     t.string "name", null: false
     t.string "product_code", null: false
@@ -62,6 +63,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_031500) do
     t.string "status", default: "active", null: false
     t.datetime "updated_at", null: false
     t.index ["asset_gl_account_id"], name: "index_account_products_on_asset_gl_account_id"
+    t.index ["interest_expense_gl_account_id"], name: "index_account_products_on_interest_expense_gl_account_id"
     t.index ["liability_gl_account_id"], name: "index_account_products_on_liability_gl_account_id"
     t.index ["product_code"], name: "index_account_products_on_product_code", unique: true
   end
@@ -396,6 +398,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_031500) do
   add_foreign_key "account_owners", "accounts"
   add_foreign_key "account_owners", "parties"
   add_foreign_key "account_products", "gl_accounts", column: "asset_gl_account_id"
+  add_foreign_key "account_products", "gl_accounts", column: "interest_expense_gl_account_id"
   add_foreign_key "account_products", "gl_accounts", column: "liability_gl_account_id"
   add_foreign_key "account_transactions", "accounts"
   add_foreign_key "account_transactions", "accounts", column: "contra_account_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -69,6 +69,7 @@ account_products_data = [
     currency_code: "USD",
     statement_cycle: "monthly",
     allow_overdraft: true,
+    interest_expense_gl_number: "5120",
     liability_gl_number: "2120"
   },
   {
@@ -78,6 +79,7 @@ account_products_data = [
     currency_code: "USD",
     statement_cycle: "monthly",
     allow_overdraft: false,
+    interest_expense_gl_number: "5130",
     liability_gl_number: "2130"
   },
   {
@@ -87,12 +89,15 @@ account_products_data = [
     currency_code: "USD",
     statement_cycle: "monthly",
     allow_overdraft: false,
+    interest_expense_gl_number: "5130",
     liability_gl_number: "2130"
   }
 ]
 
 account_products_data.each do |attrs|
   liability_gl = GlAccount.find_by!(gl_number: attrs.delete(:liability_gl_number))
+  interest_expense_gl_number = attrs.delete(:interest_expense_gl_number)
+  interest_expense_gl = GlAccount.find_by(gl_number: interest_expense_gl_number) if interest_expense_gl_number.present?
   product = AccountProduct.find_or_initialize_by(product_code: attrs[:product_code])
   product.assign_attributes(
     name: attrs[:name],
@@ -101,7 +106,8 @@ account_products_data.each do |attrs|
     statement_cycle: attrs[:statement_cycle],
     allow_overdraft: attrs[:allow_overdraft],
     status: Bankcore::Enums::STATUS_ACTIVE,
-    liability_gl_account: liability_gl
+    liability_gl_account: liability_gl,
+    interest_expense_gl_account: interest_expense_gl
   )
   product.save!
 end
@@ -261,18 +267,22 @@ if defined?(PostingTemplate)
     t.description = "GL-only: Debit interest expense, Credit interest payable"
     t.active = true
   end
-  PostingTemplateLeg.find_or_create_by!(posting_template_id: int_acc_tpl.id, position: 0) do |l|
-    l.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
-    l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-    l.gl_account_id = gl_5130.id
-    l.description = "Debit interest expense"
-  end
-  PostingTemplateLeg.find_or_create_by!(posting_template_id: int_acc_tpl.id, position: 1) do |l|
-    l.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
-    l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-    l.gl_account_id = gl_2510.id
-    l.description = "Credit interest payable"
-  end
+  int_acc_debit = PostingTemplateLeg.find_or_initialize_by(posting_template_id: int_acc_tpl.id, position: 0)
+  int_acc_debit.assign_attributes(
+    leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+    account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+    gl_account_id: nil,
+    description: "Debit product interest expense"
+  )
+  int_acc_debit.save!
+  int_acc_credit = PostingTemplateLeg.find_or_initialize_by(posting_template_id: int_acc_tpl.id, position: 1)
+  int_acc_credit.assign_attributes(
+    leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+    account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+    gl_account_id: gl_2510.id,
+    description: "Credit interest payable"
+  )
+  int_acc_credit.save!
 
   # INT_POST: Debit 2510 Interest Payable, Credit customer_account
   int_post_code = TransactionCode.find_by!(code: "INT_POST")

--- a/test/fixtures/account_products.yml
+++ b/test/fixtures/account_products.yml
@@ -18,6 +18,7 @@ now:
   currency_code: USD
   statement_cycle: monthly
   allow_overdraft: true
+  interest_expense_gl_account: nine
   status: active
   liability_gl_account: seven
   created_at: <%= ts %>
@@ -30,6 +31,7 @@ savings:
   currency_code: USD
   statement_cycle: monthly
   allow_overdraft: false
+  interest_expense_gl_account: four
   status: active
   liability_gl_account: eight
   created_at: <%= ts %>

--- a/test/fixtures/gl_accounts.yml
+++ b/test/fixtures/gl_accounts.yml
@@ -71,6 +71,15 @@ eight:
   created_at: <%= ts %>
   updated_at: <%= ts %>
 
+nine:
+  gl_number: "5120"
+  name: Interest Expense – NOW Accounts
+  category: expense
+  normal_balance: debit
+  status: active
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
 three:
   gl_number: "4510"
   name: Deposit Service Charges

--- a/test/models/account_product_test.rb
+++ b/test/models/account_product_test.rb
@@ -37,6 +37,11 @@ class AccountProductTest < ActiveSupport::TestCase
     assert_equal "disallow", account_products(:savings).default_overdraft_policy
   end
 
+  test "resolves product-aware interest expense gls" do
+    assert_equal "5120", account_products(:now).resolved_interest_expense_gl_account.gl_number
+    assert_equal "5130", account_products(:savings).resolved_interest_expense_gl_account.gl_number
+  end
+
   test "validates statement_cycle inclusion" do
     product = account_products(:dda).dup
     product.product_code = "dda_invalid_cycle"
@@ -44,5 +49,13 @@ class AccountProductTest < ActiveSupport::TestCase
 
     assert_not product.valid?
     assert_includes product.errors[:statement_cycle], "is not included in the list"
+  end
+
+  test "validates interest-bearing products require an expense gl" do
+    product = account_products(:now).dup
+    product.interest_expense_gl_account = nil
+
+    assert_not product.valid?
+    assert_includes product.errors[:interest_expense_gl_account], "must be present for interest-bearing products"
   end
 end

--- a/test/services/interest_accrual_runner_service_test.rb
+++ b/test/services/interest_accrual_runner_service_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
   def setup
-    @account = accounts(:one)
+    @account = accounts(:two)
     @accrual_date = business_dates(:one).business_date
     ensure_int_accrual_template!
     ensure_interest_bearing_deposit!
@@ -41,7 +41,7 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
   end
 
   test "skips non-interest-bearing accounts" do
-    deposit_accounts(:one).update!(interest_bearing: false, interest_rate_basis_points: 0)
+    DepositAccount.find_by!(account_id: @account.id).update!(interest_bearing: false, interest_rate_basis_points: 0)
 
     results = InterestAccrualRunnerService.run!(accrual_date: @accrual_date)
 
@@ -58,7 +58,7 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
       t.reversal_code = "INT_ACCRUAL_REVERSAL"
       t.active = true
     end
-    gl_expense = GlAccount.find_or_create_by!(gl_number: "5130") do |g|
+    GlAccount.find_or_create_by!(gl_number: "5130") do |g|
       g.name = "Interest Expense"
       g.category = "expense"
       g.normal_balance = "debit"
@@ -75,25 +75,31 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
       t.description = "GL-only accrual"
       t.active = true
     end
-    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 0) do |l|
-      l.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
-      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-      l.gl_account_id = gl_expense.id
-      l.description = "Debit interest expense"
-    end
-    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 1) do |l|
-      l.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
-      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-      l.gl_account_id = gl_payable.id
-      l.description = "Credit interest payable"
-    end
+    debit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 0)
+    debit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account_id: nil,
+      description: "Debit product interest expense"
+    )
+    debit_leg.save!
+
+    credit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 1)
+    credit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account_id: gl_payable.id,
+      description: "Credit interest payable"
+    )
+    credit_leg.save!
   end
 
   def ensure_interest_bearing_deposit!
-    deposit_accounts(:one).update!(
-      interest_bearing: true,
-      interest_rate_basis_points: 365 # ~3.65% annual = ~0.01% daily, 100000 cents = $1000 -> ~1 cent/day
-    )
+    deposit_account = DepositAccount.find_or_initialize_by(account_id: @account.id)
+    deposit_account.deposit_type ||= @account.account_product.default_deposit_type
+    deposit_account.interest_bearing = true
+    deposit_account.interest_rate_basis_points = 365 # ~3.65% annual = ~0.01% daily, 100000 cents = $1000 -> ~1 cent/day
+    deposit_account.save!
   end
 
   def ensure_balance!

--- a/test/services/interest_accrual_service_test.rb
+++ b/test/services/interest_accrual_service_test.rb
@@ -4,14 +4,15 @@ require "test_helper"
 
 class InterestAccrualServiceTest < ActiveSupport::TestCase
   def setup
-    @account = accounts(:one)
-    @other_account = Account.create!(
+    @account = create_interest_account(
       account_number: "2002",
-      account_type: @account.account_type,
-      branch: @account.branch,
-      currency_code: @account.currency_code,
-      status: Bankcore::Enums::STATUS_ACTIVE,
-      opened_on: @account.opened_on
+      product: account_products(:now),
+      rate_basis_points: 365
+    )
+    @other_account = create_interest_account(
+      account_number: "2003",
+      product: account_products(:savings),
+      rate_basis_points: 365
     )
     @accrual_date = business_dates(:one).business_date
     ensure_int_accrual_template!
@@ -100,6 +101,28 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "uses product-aware interest expense gl for now products" do
+    batch = InterestAccrualService.accrue!(
+      account_id: @account.id,
+      amount_cents: 150,
+      accrual_date: @accrual_date
+    )
+
+    gl_numbers = batch.posting_legs.includes(:gl_account).order(:position).map { |leg| leg.gl_account.gl_number }
+    assert_equal %w[5120 2510], gl_numbers
+  end
+
+  test "uses product-aware interest expense gl for savings products" do
+    batch = InterestAccrualService.accrue!(
+      account_id: @other_account.id,
+      amount_cents: 150,
+      accrual_date: @accrual_date
+    )
+
+    gl_numbers = batch.posting_legs.includes(:gl_account).order(:position).map { |leg| leg.gl_account.gl_number }
+    assert_equal %w[5130 2510], gl_numbers
+  end
+
   private
 
   def with_stubbed_class_method(klass, method_name, replacement)
@@ -118,7 +141,7 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
       t.reversal_code = "INT_ACCRUAL_REVERSAL"
       t.active = true
     end
-    gl_expense = GlAccount.find_or_create_by!(gl_number: "5130") do |g|
+    GlAccount.find_or_create_by!(gl_number: "5130") do |g|
       g.name = "Interest Expense"
       g.category = "expense"
       g.normal_balance = "debit"
@@ -135,17 +158,43 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
       t.description = "GL-only accrual"
       t.active = true
     end
-    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 0) do |l|
-      l.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
-      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-      l.gl_account_id = gl_expense.id
-      l.description = "Debit interest expense"
-    end
-    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 1) do |l|
-      l.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
-      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-      l.gl_account_id = gl_payable.id
-      l.description = "Credit interest payable"
-    end
+    debit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 0)
+    debit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account_id: nil,
+      description: "Debit product interest expense"
+    )
+    debit_leg.save!
+
+    credit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 1)
+    credit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account_id: gl_payable.id,
+      description: "Credit interest payable"
+    )
+    credit_leg.save!
+  end
+
+  def create_interest_account(account_number:, product:, rate_basis_points:)
+    account = Account.create!(
+      account_number: account_number,
+      account_type: product.product_code,
+      account_product: product,
+      branch: branches(:one),
+      currency_code: product.currency_code,
+      status: Bankcore::Enums::STATUS_ACTIVE,
+      opened_on: Date.current
+    )
+
+    DepositAccount.create!(
+      account: account,
+      deposit_type: product.default_deposit_type,
+      interest_bearing: true,
+      interest_rate_basis_points: rate_basis_points
+    )
+
+    account
   end
 end


### PR DESCRIPTION
Closes #30

## Summary
- Add product-level interest expense GL configuration on account products so interest-bearing deposit products can report accrual expense by product line.
- Route `INT_ACCRUAL` expense through the accrued account's product instead of a single fixed expense GL, while keeping the accrued interest payable leg fixed.
- Update seeds, fixtures, and accrual tests to cover NOW vs savings product routing.

## Test plan
- [x] `bin/rails test test/models/account_product_test.rb test/services/interest_accrual_service_test.rb test/services/interest_accrual_runner_service_test.rb`
- [x] `bin/rails test`

## Migration/data impact
- Adds `account_products.interest_expense_gl_account_id`.
- Backfills existing interest-bearing deposit products to `5120` for NOW and `5130` for savings/CD products.
- Updates seeded `INT_ACCRUAL` template behavior so the debit leg is supplied by product-level GL resolution.

## Financial risk
- No change to balanced posting or atomic posting requirements.
- Changes are limited to which interest expense GL receives the debit for `INT_ACCRUAL`.

## Rollback notes
- Revert the branch and roll back the Phase 3 account_products migration if product-level interest expense routing needs to be withdrawn.

## UI screenshots
- Not applicable; no user-facing UI changes in this slice.

Made with [Cursor](https://cursor.com)