### PR TITLE
Add product-based fee rules

### DIFF
--- a/app/models/account_product.rb
+++ b/app/models/account_product.rb
@@ -12,6 +12,7 @@ class AccountProduct < ApplicationRecord
   belongs_to :interest_expense_gl_account, class_name: "GlAccount", optional: true
 
   has_many :accounts, dependent: :restrict_with_error
+  has_many :fee_rules, dependent: :restrict_with_error
 
   validates :product_code, presence: true, uniqueness: true
   validates :name, presence: true

--- a/app/models/fee_assessment.rb
+++ b/app/models/fee_assessment.rb
@@ -5,6 +5,7 @@ class FeeAssessment < ApplicationRecord
 
   belongs_to :account
   belongs_to :fee_type
+  belongs_to :fee_rule, optional: true
   belongs_to :posting_batch, optional: true
 
   validates :amount_cents, presence: true, numericality: { greater_than: 0 }

--- a/app/models/fee_rule.rb
+++ b/app/models/fee_rule.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class FeeRule < ApplicationRecord
+  METHOD_FIXED_AMOUNT = "fixed_amount"
+  METHODS = [ METHOD_FIXED_AMOUNT ].freeze
+
+  belongs_to :fee_type
+  belongs_to :account_product
+  belongs_to :gl_account, optional: true
+
+  has_many :fee_assessments, dependent: :restrict_with_error
+
+  validates :priority, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :method, presence: true, inclusion: { in: METHODS }
+  validates :amount_cents, numericality: { greater_than: 0 }, allow_nil: true
+  validate :active_range_is_valid
+
+  scope :active_on, lambda { |date|
+    where("effective_on IS NULL OR effective_on <= ?", date)
+      .where("ends_on IS NULL OR ends_on >= ?", date)
+  }
+  scope :ordered, -> { order(:priority, :id) }
+
+  def amount_cents_for_assessment
+    amount_cents || fee_type.default_amount_cents
+  end
+
+  def gl_account_id_for_posting
+    gl_account_id || fee_type.gl_account_id
+  end
+
+  private
+
+  def active_range_is_valid
+    return if effective_on.blank? || ends_on.blank?
+    return if ends_on >= effective_on
+
+    errors.add(:ends_on, "must be on or after effective_on")
+  end
+end

--- a/app/models/fee_type.rb
+++ b/app/models/fee_type.rb
@@ -5,6 +5,7 @@ class FeeType < ApplicationRecord
 
   belongs_to :gl_account, optional: true
   has_many :fee_assessments, dependent: :restrict_with_error
+  has_many :fee_rules, dependent: :restrict_with_error
 
   validates :code, presence: true, uniqueness: true
   validates :name, presence: true

--- a/app/services/fee_assessment_runner_service.rb
+++ b/app/services/fee_assessment_runner_service.rb
@@ -2,7 +2,7 @@
 
 class FeeAssessmentRunnerService
   # Runs fee assessment for a fee type across eligible accounts.
-  # MVP rule: all active DDA accounts.
+  # Phase 4 rule: active fee_rules tied to account products.
   def self.run!(fee_type_id:, assessment_date: nil)
     new(fee_type_id: fee_type_id, assessment_date: assessment_date).run!
   end
@@ -26,12 +26,17 @@ class FeeAssessmentRunnerService
   private
 
   def eligible_accounts
+    return Account.none if active_rules_by_product.empty?
+
     Account
-      .where(account_type: "dda", status: Bankcore::Enums::STATUS_ACTIVE)
+      .includes(:account_product)
+      .where(status: Bankcore::Enums::STATUS_ACTIVE, account_product_id: active_rules_by_product.keys)
   end
 
   def assess_account(account)
     account_id = account.id
+    fee_rule = active_rules_by_product[account.account_product_id]
+    return { status: :skipped, account_id: account_id, reason: "no_rule" } unless fee_rule
 
     if already_assessed?(account_id)
       return { status: :skipped, account_id: account_id, reason: "already_assessed" }
@@ -40,11 +45,14 @@ class FeeAssessmentRunnerService
     FeePostingService.assess!(
       account_id: account_id,
       fee_type_id: @fee_type_id,
+      fee_rule_id: fee_rule.id,
+      amount_cents: fee_rule.amount_cents_for_assessment,
+      gl_account_id: fee_rule.gl_account_id_for_posting,
       business_date: @assessment_date,
       idempotency_key: idempotency_key(account_id)
     )
 
-    { status: :assessed, account_id: account_id }
+    { status: :assessed, account_id: account_id, fee_rule_id: fee_rule.id }
   rescue StandardError => e
     { status: :errors, account_id: account_id, error: e.message }
   end
@@ -59,5 +67,16 @@ class FeeAssessmentRunnerService
 
   def idempotency_key(account_id)
     "fee-#{@fee_type_id}-#{account_id}-#{@assessment_date}"
+  end
+
+  def active_rules_by_product
+    @active_rules_by_product ||= FeeRule
+      .includes(:fee_type)
+      .where(fee_type_id: @fee_type_id)
+      .active_on(@assessment_date)
+      .ordered
+      .each_with_object({}) do |fee_rule, result|
+        result[fee_rule.account_product_id] ||= fee_rule
+      end
   end
 end

--- a/app/services/fee_posting_service.rb
+++ b/app/services/fee_posting_service.rb
@@ -3,22 +3,34 @@
 class FeePostingService
   include Bankcore::Enums
 
-  def self.assess!(account_id:, fee_type_id:, amount_cents: nil, business_date: nil, idempotency_key: nil)
-    new(account_id: account_id, fee_type_id: fee_type_id, amount_cents: amount_cents,
-        business_date: business_date, idempotency_key: idempotency_key).assess!
+  def self.assess!(account_id:, fee_type_id:, amount_cents: nil, business_date: nil, idempotency_key: nil,
+                   fee_rule_id: nil, gl_account_id: nil)
+    new(
+      account_id: account_id,
+      fee_type_id: fee_type_id,
+      amount_cents: amount_cents,
+      business_date: business_date,
+      idempotency_key: idempotency_key,
+      fee_rule_id: fee_rule_id,
+      gl_account_id: gl_account_id
+    ).assess!
   end
 
-  def initialize(account_id:, fee_type_id:, amount_cents: nil, business_date: nil, idempotency_key: nil)
+  def initialize(account_id:, fee_type_id:, amount_cents: nil, business_date: nil, idempotency_key: nil,
+                 fee_rule_id: nil, gl_account_id: nil)
     @account_id = account_id
     @fee_type_id = fee_type_id
     @amount_cents = amount_cents
     @business_date = business_date || BusinessDateService.current
     @idempotency_key = idempotency_key
+    @fee_rule_id = fee_rule_id
+    @gl_account_id = gl_account_id
   end
 
   def assess!
     fee_type = FeeType.find(@fee_type_id)
     amount = @amount_cents || fee_type.default_amount_cents
+    posting_gl_account_id = @gl_account_id || fee_type.gl_account_id
     raise ArgumentError, "Amount must be positive" if amount.to_i <= 0
 
     ActiveRecord::Base.transaction do
@@ -28,16 +40,18 @@ class FeePostingService
         amount_cents: amount,
         business_date: @business_date,
         idempotency_key: @idempotency_key,
-        gl_account_id: fee_type.gl_account_id,
+        gl_account_id: posting_gl_account_id,
         idempotency_context: {
           service: "fee_posting",
-          fee_type_id: @fee_type_id
+          fee_type_id: @fee_type_id,
+          fee_rule_id: @fee_rule_id
         }
       )
 
       FeeAssessment.find_or_create_by!(posting_batch_id: batch.id) do |assessment|
         assessment.account_id = @account_id
         assessment.fee_type_id = @fee_type_id
+        assessment.fee_rule_id = @fee_rule_id
         assessment.amount_cents = amount
         assessment.assessed_on = @business_date
         assessment.status = Bankcore::Enums::STATUS_POSTED

--- a/db/migrate/20260309050000_create_fee_rules_and_link_fee_assessments.rb
+++ b/db/migrate/20260309050000_create_fee_rules_and_link_fee_assessments.rb
@@ -1,0 +1,22 @@
+class CreateFeeRulesAndLinkFeeAssessments < ActiveRecord::Migration[8.1]
+  def change
+    create_table :fee_rules do |t|
+      t.references :fee_type, null: false, foreign_key: true
+      t.references :account_product, null: false, foreign_key: true
+      t.references :gl_account, foreign_key: true
+      t.integer :priority, null: false, default: 100
+      t.string :method, null: false, default: "fixed_amount"
+      t.integer :amount_cents
+      t.text :conditions_json
+      t.date :effective_on
+      t.date :ends_on
+
+      t.timestamps
+    end
+
+    add_index :fee_rules, [ :fee_type_id, :account_product_id, :priority ], unique: true,
+      name: "index_fee_rules_on_fee_type_product_priority"
+
+    add_reference :fee_assessments, :fee_rule, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_040000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_050000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -159,14 +159,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_040000) do
     t.integer "amount_cents", null: false
     t.date "assessed_on", null: false
     t.datetime "created_at", null: false
+    t.bigint "fee_rule_id"
     t.bigint "fee_type_id", null: false
     t.bigint "posting_batch_id"
     t.string "status", default: "posted", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id", "assessed_on"], name: "index_fee_assessments_on_account_id_and_assessed_on"
     t.index ["account_id"], name: "index_fee_assessments_on_account_id"
+    t.index ["fee_rule_id"], name: "index_fee_assessments_on_fee_rule_id"
     t.index ["fee_type_id"], name: "index_fee_assessments_on_fee_type_id"
     t.index ["posting_batch_id"], name: "index_fee_assessments_on_posting_batch_id"
+  end
+
+  create_table "fee_rules", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "account_product_id", null: false
+    t.integer "amount_cents"
+    t.text "conditions_json"
+    t.datetime "created_at", null: false
+    t.date "effective_on"
+    t.date "ends_on"
+    t.bigint "fee_type_id", null: false
+    t.bigint "gl_account_id"
+    t.string "method", default: "fixed_amount", null: false
+    t.integer "priority", default: 100, null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_product_id"], name: "index_fee_rules_on_account_product_id"
+    t.index ["fee_type_id", "account_product_id", "priority"], name: "index_fee_rules_on_fee_type_product_priority", unique: true
+    t.index ["fee_type_id"], name: "index_fee_rules_on_fee_type_id"
+    t.index ["gl_account_id"], name: "index_fee_rules_on_gl_account_id"
   end
 
   create_table "fee_types", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -408,8 +428,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_040000) do
   add_foreign_key "accounts", "branches"
   add_foreign_key "deposit_accounts", "accounts"
   add_foreign_key "fee_assessments", "accounts"
+  add_foreign_key "fee_assessments", "fee_rules"
   add_foreign_key "fee_assessments", "fee_types"
   add_foreign_key "fee_assessments", "posting_batches"
+  add_foreign_key "fee_rules", "account_products"
+  add_foreign_key "fee_rules", "fee_types"
+  add_foreign_key "fee_rules", "gl_accounts"
   add_foreign_key "fee_types", "gl_accounts"
   add_foreign_key "gl_accounts", "gl_accounts", column: "parent_gl_account_id"
   add_foreign_key "interest_accruals", "accounts"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,17 +248,21 @@ if defined?(PostingTemplate)
     t.description = "Debit account, Credit fee income"
     t.active = true
   end
-  PostingTemplateLeg.find_or_create_by!(posting_template_id: fee_tpl.id, position: 0) do |l|
-    l.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
-    l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER
-    l.description = "Debit customer account"
-  end
-  PostingTemplateLeg.find_or_create_by!(posting_template_id: fee_tpl.id, position: 1) do |l|
-    l.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
-    l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-    l.gl_account_id = gl_4510.id
-    l.description = "Credit fee income"
-  end
+  fee_debit = PostingTemplateLeg.find_or_initialize_by(posting_template_id: fee_tpl.id, position: 0)
+  fee_debit.assign_attributes(
+    leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+    account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+    description: "Debit customer account"
+  )
+  fee_debit.save!
+  fee_credit = PostingTemplateLeg.find_or_initialize_by(posting_template_id: fee_tpl.id, position: 1)
+  fee_credit.assign_attributes(
+    leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+    account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+    gl_account_id: nil,
+    description: "Credit fee income"
+  )
+  fee_credit.save!
 
   # INT_ACCRUAL: Debit 5130 Interest Expense, Credit 2510 Interest Payable (GL-only)
   int_acc_code = TransactionCode.find_by!(code: "INT_ACCRUAL")
@@ -457,6 +461,7 @@ deposit_account.save!
 # 8. Fee Types (Phase 5)
 if defined?(FeeType)
   gl_4510 = GlAccount.find_by!(gl_number: "4510")
+  gl_4560 = GlAccount.find_by!(gl_number: "4560")
   FeeType.find_or_create_by!(code: "MAINTENANCE") do |ft|
     ft.name = "Monthly Maintenance Fee"
     ft.default_amount_cents = 1500 # $15.00
@@ -468,6 +473,41 @@ if defined?(FeeType)
     ft.default_amount_cents = 500 # $5.00
     ft.gl_account_id = gl_4510.id
     ft.status = Bankcore::Enums::STATUS_ACTIVE
+  end
+
+  if defined?(FeeRule)
+    maintenance_fee = FeeType.find_by!(code: "MAINTENANCE")
+    service_charge_fee = FeeType.find_by!(code: "SERVICE_CHARGE")
+
+    [
+      {
+        fee_type: maintenance_fee,
+        account_product: AccountProduct.find_by!(product_code: "dda"),
+        amount_cents: 1500,
+        gl_account: maintenance_fee.gl_account,
+        effective_on: Date.current.beginning_of_month
+      },
+      {
+        fee_type: service_charge_fee,
+        account_product: AccountProduct.find_by!(product_code: "savings"),
+        amount_cents: 700,
+        gl_account: gl_4560,
+        effective_on: Date.current.beginning_of_month
+      }
+    ].each do |attrs|
+      fee_rule = FeeRule.find_or_initialize_by(
+        fee_type: attrs[:fee_type],
+        account_product: attrs[:account_product],
+        priority: 100
+      )
+      fee_rule.assign_attributes(
+        method: FeeRule::METHOD_FIXED_AMOUNT,
+        amount_cents: attrs[:amount_cents],
+        gl_account: attrs[:gl_account],
+        effective_on: attrs[:effective_on]
+      )
+      fee_rule.save!
+    end
   end
 end
 

--- a/test/fixtures/fee_rules.yml
+++ b/test/fixtures/fee_rules.yml
@@ -1,0 +1,21 @@
+<% ts = Time.zone.parse("2026-03-07 12:00:00") %>
+maintenance_dda:
+  fee_type: maintenance
+  account_product: dda
+  priority: 100
+  method: fixed_amount
+  amount_cents: 1500
+  effective_on: 2026-03-01
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
+service_charge_savings:
+  fee_type: service_charge
+  account_product: savings
+  gl_account: eleven
+  priority: 100
+  method: fixed_amount
+  amount_cents: 700
+  effective_on: 2026-03-01
+  created_at: <%= ts %>
+  updated_at: <%= ts %>

--- a/test/fixtures/fee_types.yml
+++ b/test/fixtures/fee_types.yml
@@ -1,0 +1,18 @@
+<% ts = Time.zone.parse("2026-03-07 12:00:00") %>
+maintenance:
+  code: MAINTENANCE
+  name: Monthly Maintenance Fee
+  default_amount_cents: 1500
+  gl_account: three
+  status: active
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
+service_charge:
+  code: SERVICE_CHARGE
+  name: Service Charge
+  default_amount_cents: 500
+  gl_account: three
+  status: active
+  created_at: <%= ts %>
+  updated_at: <%= ts %>

--- a/test/fixtures/gl_accounts.yml
+++ b/test/fixtures/gl_accounts.yml
@@ -80,6 +80,24 @@ nine:
   created_at: <%= ts %>
   updated_at: <%= ts %>
 
+ten:
+  gl_number: "4540"
+  name: NSF / Overdraft Fees
+  category: income
+  normal_balance: credit
+  status: active
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
+eleven:
+  gl_number: "4560"
+  name: Miscellaneous Income
+  category: income
+  normal_balance: credit
+  status: active
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
 three:
   gl_number: "4510"
   name: Deposit Service Charges

--- a/test/models/fee_rule_test.rb
+++ b/test/models/fee_rule_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FeeRuleTest < ActiveSupport::TestCase
+  test "uses fee type defaults when rule amount or gl override are blank" do
+    fee_rule = FeeRule.new(
+      fee_type: fee_types(:maintenance),
+      account_product: account_products(:dda),
+      priority: 100,
+      method: FeeRule::METHOD_FIXED_AMOUNT
+    )
+
+    assert_equal 1500, fee_rule.amount_cents_for_assessment
+    assert_equal fee_types(:maintenance).gl_account_id, fee_rule.gl_account_id_for_posting
+  end
+
+  test "validates active range ordering" do
+    fee_rule = FeeRule.new(
+      fee_type: fee_types(:maintenance),
+      account_product: account_products(:dda),
+      priority: 100,
+      method: FeeRule::METHOD_FIXED_AMOUNT,
+      effective_on: Date.new(2026, 3, 31),
+      ends_on: Date.new(2026, 3, 1)
+    )
+
+    assert_not fee_rule.valid?
+    assert_includes fee_rule.errors[:ends_on], "must be on or after effective_on"
+  end
+end

--- a/test/services/fee_assessment_runner_service_test.rb
+++ b/test/services/fee_assessment_runner_service_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FeeAssessmentRunnerServiceTest < ActiveSupport::TestCase
+  def setup
+    @business_date = business_dates(:one).business_date
+    ensure_fee_post_template!
+  end
+
+  test "assesses only accounts whose products have active rules for the fee type" do
+    results = FeeAssessmentRunnerService.run!(
+      fee_type_id: fee_types(:maintenance).id,
+      assessment_date: @business_date
+    )
+
+    assert_equal [ accounts(:one).id ], results[:assessed].map { |result| result[:account_id] }
+    assert_empty results[:errors]
+    refute_includes results[:assessed].map { |result| result[:account_id] }, accounts(:two).id
+  end
+
+  test "uses fee rule amount and gl override for matching product" do
+    results = FeeAssessmentRunnerService.run!(
+      fee_type_id: fee_types(:service_charge).id,
+      assessment_date: @business_date
+    )
+
+    assert_equal [ accounts(:two).id ], results[:assessed].map { |result| result[:account_id] }
+
+    assessment = FeeAssessment.find_by!(
+      account_id: accounts(:two).id,
+      fee_type_id: fee_types(:service_charge).id,
+      assessed_on: @business_date
+    )
+    gl_numbers = assessment.posting_batch.posting_legs.includes(:gl_account).map { |leg| leg.gl_account&.gl_number }.compact
+
+    assert_equal fee_rules(:service_charge_savings).id, assessment.fee_rule_id
+    assert_equal 700, assessment.amount_cents
+    assert_equal [ "4560" ], gl_numbers
+  end
+
+  test "returns no assessments when no active rules exist for the fee type" do
+    results = FeeAssessmentRunnerService.run!(
+      fee_type_id: FeeType.create!(
+        code: "UNRULED_FEE",
+        name: "Unruled Fee",
+        default_amount_cents: 100,
+        gl_account: gl_accounts(:three),
+        status: Bankcore::Enums::STATUS_ACTIVE
+      ).id,
+      assessment_date: @business_date
+    )
+
+    assert_empty results[:assessed]
+    assert_empty results[:errors]
+  end
+
+  private
+
+  def ensure_fee_post_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "FEE_POST" })
+
+    tc = TransactionCode.find_or_create_by!(code: "FEE_POST") do |t|
+      t.description = "Fee assessment"
+      t.reversal_code = "FEE_REVERSAL"
+      t.active = true
+    end
+    tpl = PostingTemplate.find_or_create_by!(transaction_code_id: tc.id) do |t|
+      t.name = "Fee Assessment"
+      t.description = "Debit account, Credit fee income"
+      t.active = true
+    end
+    debit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 0)
+    debit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Debit customer account"
+    )
+    debit_leg.save!
+
+    credit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 1)
+    credit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account_id: nil,
+      description: "Credit fee income"
+    )
+    credit_leg.save!
+  end
+end

--- a/test/services/fee_posting_service_test.rb
+++ b/test/services/fee_posting_service_test.rb
@@ -123,6 +123,34 @@ class FeePostingServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "stores fee rule linkage and uses rule gl override when provided" do
+    rule = FeeRule.create!(
+      fee_type: @fee_type,
+      account_product: accounts(:two).account_product,
+      gl_account: GlAccount.find_by!(gl_number: "4560"),
+      priority: 100,
+      method: FeeRule::METHOD_FIXED_AMOUNT,
+      amount_cents: 700,
+      effective_on: @business_date
+    )
+
+    batch = FeePostingService.assess!(
+      account_id: accounts(:two).id,
+      fee_type_id: @fee_type.id,
+      fee_rule_id: rule.id,
+      amount_cents: rule.amount_cents_for_assessment,
+      gl_account_id: rule.gl_account_id_for_posting,
+      business_date: @business_date
+    )
+
+    assessment = FeeAssessment.find_by!(posting_batch_id: batch.id)
+    gl_numbers = batch.posting_legs.includes(:gl_account).order(:position).map { |leg| leg.gl_account&.gl_number }.compact
+
+    assert_equal rule.id, assessment.fee_rule_id
+    assert_equal 700, assessment.amount_cents
+    assert_equal [ "4560" ], gl_numbers
+  end
+
   private
 
   def with_stubbed_class_method(klass, method_name, replacement)
@@ -152,16 +180,21 @@ class FeePostingServiceTest < ActiveSupport::TestCase
       t.description = "Debit account, Credit fee income"
       t.active = true
     end
-    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 0) do |l|
-      l.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
-      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER
-      l.description = "Debit customer account"
-    end
-    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 1) do |l|
-      l.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
-      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
-      l.gl_account_id = gl.id
-      l.description = "Credit fee income"
-    end
+    debit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 0)
+    debit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Debit customer account"
+    )
+    debit_leg.save!
+
+    credit_leg = PostingTemplateLeg.find_or_initialize_by(posting_template_id: tpl.id, position: 1)
+    credit_leg.assign_attributes(
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account_id: nil,
+      description: "Credit fee income"
+    )
+    credit_leg.save!
   end
 end


### PR DESCRIPTION
Closes #32

## Summary
- Add product-linked `fee_rules` so scheduled fee assessment can be configured by account product instead of hardcoded account-type filters.
- Update the fee runner to select eligible accounts from active product rules and carry the triggering fee rule into each fee assessment record.
- Support fee rule overrides for amount and fee income GL while keeping fee posting inside the existing posting engine path.

## Test plan
- [x] `bin/rails test test/models/fee_rule_test.rb test/services/fee_posting_service_test.rb test/services/fee_assessment_runner_service_test.rb`
- [x] `bin/rails test`

## Migration/data impact
- Adds `fee_rules` and links `fee_assessments.fee_rule_id`.
- Seeds default maintenance and service-charge fee rules for DDA and savings products.
- Updates `FEE_POST` seed template behavior so the credit GL can be supplied by the selected fee rule.

## Financial risk
- No change to balanced posting or posting atomicity requirements.
- Changes are limited to fee eligibility, rule-driven fee amounts, and fee income GL routing.

## Rollback notes
- Revert the branch and roll back the fee-rules migration if the rule-driven fee model needs to be withdrawn.

## UI screenshots
- Not applicable; no user-facing UI changes in this slice.

Made with [Cursor](https://cursor.com)