### PR TITLE
Add product-based interest rules

### DIFF
--- a/app/models/account_product.rb
+++ b/app/models/account_product.rb
@@ -13,6 +13,7 @@ class AccountProduct < ApplicationRecord
 
   has_many :accounts, dependent: :restrict_with_error
   has_many :fee_rules, dependent: :restrict_with_error
+  has_many :interest_rules, dependent: :restrict_with_error
 
   validates :product_code, presence: true, uniqueness: true
   validates :name, presence: true

--- a/app/models/interest_accrual.rb
+++ b/app/models/interest_accrual.rb
@@ -4,6 +4,7 @@ class InterestAccrual < ApplicationRecord
   include Bankcore::Enums
 
   belongs_to :account
+  belongs_to :interest_rule, optional: true
   belongs_to :posting_batch, optional: true
 
   validates :accrual_date, presence: true

--- a/app/models/interest_rule.rb
+++ b/app/models/interest_rule.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class InterestRule < ApplicationRecord
+  DAY_COUNT_METHOD_ACTUAL_365 = "actual_365"
+  DAY_COUNT_METHOD_30_360 = "30_360"
+  DAY_COUNT_METHODS = [ DAY_COUNT_METHOD_ACTUAL_365, DAY_COUNT_METHOD_30_360 ].freeze
+
+  POSTING_CADENCE_MONTHLY = "monthly"
+  POSTING_CADENCE_QUARTERLY = "quarterly"
+  POSTING_CADENCE_ANNUAL = "annual"
+  POSTING_CADENCES = [
+    POSTING_CADENCE_MONTHLY,
+    POSTING_CADENCE_QUARTERLY,
+    POSTING_CADENCE_ANNUAL
+  ].freeze
+
+  belongs_to :account_product
+
+  has_many :interest_accruals, dependent: :restrict_with_error
+
+  validates :rate, presence: true, numericality: { greater_than: 0 }
+  validates :day_count_method, presence: true, inclusion: { in: DAY_COUNT_METHODS }
+  validates :posting_cadence, presence: true, inclusion: { in: POSTING_CADENCES }
+  validate :active_range_is_valid
+
+  scope :active_on, lambda { |date|
+    where("effective_on IS NULL OR effective_on <= ?", date)
+      .where("ends_on IS NULL OR ends_on >= ?", date)
+  }
+  scope :ordered, -> { order(effective_on: :desc, id: :desc) }
+
+  private
+
+  def active_range_is_valid
+    return if effective_on.blank? || ends_on.blank?
+    return if ends_on >= effective_on
+
+    errors.add(:ends_on, "must be on or after effective_on")
+  end
+end

--- a/app/services/interest_accrual_runner_service.rb
+++ b/app/services/interest_accrual_runner_service.rb
@@ -2,7 +2,7 @@
 
 class InterestAccrualRunnerService
   # Runs daily interest accrual for all eligible deposit accounts.
-  # Finds interest-bearing accounts with positive balance, calculates daily interest,
+  # Finds interest-bearing accounts with active product rules, calculates daily interest,
   # and posts via InterestAccrualService.
   def self.run!(accrual_date: nil)
     new(accrual_date: accrual_date).run!
@@ -26,15 +26,19 @@ class InterestAccrualRunnerService
   private
 
   def eligible_accounts
+    return DepositAccount.none if active_rules_by_product.empty?
+
     DepositAccount
       .joins(:account)
       .where(interest_bearing: true)
-      .where("deposit_accounts.interest_rate_basis_points > 0")
+      .where(accounts: { account_product_id: active_rules_by_product.keys })
       .where(accounts: { status: Bankcore::Enums::STATUS_ACTIVE })
   end
 
   def accrue_account(deposit_account)
     account_id = deposit_account.account_id
+    interest_rule = active_rules_by_product[deposit_account.account.account_product_id]
+    return { status: :skipped, account_id: account_id, reason: "no_rule" } unless interest_rule
 
     if already_accrued?(account_id)
       return { status: :skipped, account_id: account_id, reason: "already_accrued" }
@@ -47,7 +51,8 @@ class InterestAccrualRunnerService
 
     amount_cents = calculate_daily_interest(
       balance_cents,
-      deposit_account.interest_rate_basis_points
+      resolved_annual_rate(deposit_account, interest_rule),
+      interest_rule.day_count_method
     )
     if amount_cents <= 0
       return { status: :skipped, account_id: account_id, reason: "rounds_to_zero" }
@@ -57,10 +62,11 @@ class InterestAccrualRunnerService
       account_id: account_id,
       amount_cents: amount_cents,
       accrual_date: @accrual_date,
-      idempotency_key: idempotency_key(account_id)
+      idempotency_key: idempotency_key(account_id),
+      interest_rule_id: interest_rule.id
     )
 
-    { status: :accrued, account_id: account_id, amount_cents: amount_cents }
+    { status: :accrued, account_id: account_id, amount_cents: amount_cents, interest_rule_id: interest_rule.id }
   rescue StandardError => e
     { status: :errors, account_id: account_id, error: e.message }
   end
@@ -79,13 +85,42 @@ class InterestAccrualRunnerService
     balance.posted_balance_cents.to_i
   end
 
-  def calculate_daily_interest(balance_cents, rate_basis_points)
-    # Daily interest = balance * (rate/10000) / 365
+  def calculate_daily_interest(balance_cents, annual_rate, day_count_method)
+    denominator = day_count_denominator(day_count_method)
+    # Daily interest = balance * annual_rate / day_count_denominator
     # Use floor to avoid over-accruing
-    (balance_cents * rate_basis_points / (10_000.0 * 365)).floor
+    (balance_cents * annual_rate.to_d / denominator).floor
   end
 
   def idempotency_key(account_id)
     "int-accrual-#{account_id}-#{@accrual_date}"
+  end
+
+  def active_rules_by_product
+    @active_rules_by_product ||= InterestRule
+      .where(account_product_id: eligible_product_ids)
+      .active_on(@accrual_date)
+      .ordered
+      .each_with_object({}) do |interest_rule, result|
+        result[interest_rule.account_product_id] ||= interest_rule
+      end
+  end
+
+  def eligible_product_ids
+    AccountProduct.where(status: Bankcore::Enums::STATUS_ACTIVE).pluck(:id)
+  end
+
+  def resolved_annual_rate(deposit_account, interest_rule)
+    override_basis_points = deposit_account.interest_rate_basis_points.to_i
+    return BigDecimal(override_basis_points.to_s) / 10_000 if override_basis_points.positive?
+
+    interest_rule.rate.to_d
+  end
+
+  def day_count_denominator(day_count_method)
+    case day_count_method
+    when InterestRule::DAY_COUNT_METHOD_30_360 then 360
+    else 365
+    end
   end
 end

--- a/app/services/interest_accrual_service.rb
+++ b/app/services/interest_accrual_service.rb
@@ -3,16 +3,17 @@
 class InterestAccrualService
   include Bankcore::Enums
 
-  def self.accrue!(account_id:, amount_cents:, accrual_date: nil, idempotency_key: nil)
+  def self.accrue!(account_id:, amount_cents:, accrual_date: nil, idempotency_key: nil, interest_rule_id: nil)
     new(account_id: account_id, amount_cents: amount_cents, accrual_date: accrual_date,
-        idempotency_key: idempotency_key).accrue!
+        idempotency_key: idempotency_key, interest_rule_id: interest_rule_id).accrue!
   end
 
-  def initialize(account_id:, amount_cents:, accrual_date: nil, idempotency_key: nil)
+  def initialize(account_id:, amount_cents:, accrual_date: nil, idempotency_key: nil, interest_rule_id: nil)
     @account_id = account_id
     @amount_cents = amount_cents
     @accrual_date = accrual_date || BusinessDateService.current
     @idempotency_key = idempotency_key
+    @interest_rule_id = interest_rule_id
   end
 
   def accrue!
@@ -36,6 +37,7 @@ class InterestAccrualService
 
       InterestAccrual.find_or_create_by!(posting_batch_id: batch.id) do |accrual|
         accrual.account_id = @account_id
+        accrual.interest_rule_id = @interest_rule_id
         accrual.accrual_date = @accrual_date
         accrual.amount_cents = @amount_cents
         accrual.status = Bankcore::Enums::STATUS_POSTED

--- a/db/migrate/20260309060000_create_interest_rules_and_link_interest_accruals.rb
+++ b/db/migrate/20260309060000_create_interest_rules_and_link_interest_accruals.rb
@@ -1,0 +1,17 @@
+class CreateInterestRulesAndLinkInterestAccruals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :interest_rules do |t|
+      t.references :account_product, null: false, foreign_key: true
+      t.decimal :rate, precision: 8, scale: 6, null: false
+      t.string :day_count_method, null: false, default: "actual_365"
+      t.string :posting_cadence, null: false, default: "monthly"
+      t.date :effective_on
+      t.date :ends_on
+
+      t.timestamps
+    end
+
+    add_index :interest_rules, [ :account_product_id, :effective_on ], name: "index_interest_rules_on_product_and_effective_on"
+    add_reference :interest_accruals, :interest_rule, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_050000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_060000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -221,12 +221,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_050000) do
     t.date "accrual_date", null: false
     t.integer "amount_cents", null: false
     t.datetime "created_at", null: false
+    t.bigint "interest_rule_id"
     t.bigint "posting_batch_id"
     t.string "status", default: "posted", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id", "accrual_date"], name: "index_interest_accruals_on_account_id_and_accrual_date"
     t.index ["account_id"], name: "index_interest_accruals_on_account_id"
+    t.index ["interest_rule_id"], name: "index_interest_accruals_on_interest_rule_id"
     t.index ["posting_batch_id"], name: "index_interest_accruals_on_posting_batch_id"
+  end
+
+  create_table "interest_rules", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "account_product_id", null: false
+    t.datetime "created_at", null: false
+    t.string "day_count_method", default: "actual_365", null: false
+    t.date "effective_on"
+    t.date "ends_on"
+    t.string "posting_cadence", default: "monthly", null: false
+    t.decimal "rate", precision: 8, scale: 6, null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_product_id", "effective_on"], name: "index_interest_rules_on_product_and_effective_on"
+    t.index ["account_product_id"], name: "index_interest_rules_on_account_product_id"
   end
 
   create_table "journal_entries", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -437,7 +452,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_050000) do
   add_foreign_key "fee_types", "gl_accounts"
   add_foreign_key "gl_accounts", "gl_accounts", column: "parent_gl_account_id"
   add_foreign_key "interest_accruals", "accounts"
+  add_foreign_key "interest_accruals", "interest_rules"
   add_foreign_key "interest_accruals", "posting_batches"
+  add_foreign_key "interest_rules", "account_products"
   add_foreign_key "journal_entries", "posting_batches"
   add_foreign_key "journal_entry_lines", "branches"
   add_foreign_key "journal_entry_lines", "gl_accounts"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -112,6 +112,43 @@ account_products_data.each do |attrs|
   product.save!
 end
 
+if defined?(InterestRule)
+  [
+    {
+      account_product: AccountProduct.find_by!(product_code: "now"),
+      rate: BigDecimal("0.0100"),
+      day_count_method: InterestRule::DAY_COUNT_METHOD_ACTUAL_365,
+      posting_cadence: InterestRule::POSTING_CADENCE_MONTHLY,
+      effective_on: Date.current.beginning_of_month
+    },
+    {
+      account_product: AccountProduct.find_by!(product_code: "savings"),
+      rate: BigDecimal("0.0200"),
+      day_count_method: InterestRule::DAY_COUNT_METHOD_ACTUAL_365,
+      posting_cadence: InterestRule::POSTING_CADENCE_MONTHLY,
+      effective_on: Date.current.beginning_of_month
+    },
+    {
+      account_product: AccountProduct.find_by!(product_code: "cd"),
+      rate: BigDecimal("0.0300"),
+      day_count_method: InterestRule::DAY_COUNT_METHOD_ACTUAL_365,
+      posting_cadence: InterestRule::POSTING_CADENCE_MONTHLY,
+      effective_on: Date.current.beginning_of_month
+    }
+  ].each do |attrs|
+    interest_rule = InterestRule.find_or_initialize_by(
+      account_product: attrs[:account_product],
+      effective_on: attrs[:effective_on]
+    )
+    interest_rule.assign_attributes(
+      rate: attrs[:rate],
+      day_count_method: attrs[:day_count_method],
+      posting_cadence: attrs[:posting_cadence]
+    )
+    interest_rule.save!
+  end
+end
+
 # 4. Business Date
 today = Date.current
 BusinessDate.find_or_create_by!(business_date: today) do |bd|

--- a/test/fixtures/interest_rules.yml
+++ b/test/fixtures/interest_rules.yml
@@ -1,0 +1,18 @@
+<% ts = Time.zone.parse("2026-03-07 12:00:00") %>
+now_default:
+  account_product: now
+  rate: 0.010000
+  day_count_method: actual_365
+  posting_cadence: monthly
+  effective_on: 2026-03-01
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
+savings_default:
+  account_product: savings
+  rate: 0.036500
+  day_count_method: actual_365
+  posting_cadence: monthly
+  effective_on: 2026-03-01
+  created_at: <%= ts %>
+  updated_at: <%= ts %>

--- a/test/models/interest_rule_test.rb
+++ b/test/models/interest_rule_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InterestRuleTest < ActiveSupport::TestCase
+  test "active_on returns rules effective for the given date" do
+    active_rules = InterestRule.active_on(Date.new(2026, 3, 7))
+
+    assert_includes active_rules, interest_rules(:now_default)
+    assert_includes active_rules, interest_rules(:savings_default)
+  end
+
+  test "validates active range ordering" do
+    interest_rule = InterestRule.new(
+      account_product: account_products(:savings),
+      rate: 0.025,
+      day_count_method: InterestRule::DAY_COUNT_METHOD_ACTUAL_365,
+      posting_cadence: InterestRule::POSTING_CADENCE_MONTHLY,
+      effective_on: Date.new(2026, 3, 31),
+      ends_on: Date.new(2026, 3, 1)
+    )
+
+    assert_not interest_rule.valid?
+    assert_includes interest_rule.errors[:ends_on], "must be on or after effective_on"
+  end
+end

--- a/test/services/interest_accrual_runner_service_test.rb
+++ b/test/services/interest_accrual_runner_service_test.rb
@@ -6,6 +6,7 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
   def setup
     @account = accounts(:two)
     @accrual_date = business_dates(:one).business_date
+    @interest_rule = interest_rules(:savings_default)
     ensure_int_accrual_template!
     ensure_interest_bearing_deposit!
     ensure_balance!
@@ -17,10 +18,12 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
     assert_equal 1, results[:accrued].size
     assert results[:accrued].first[:amount_cents].positive?
     assert_equal @account.id, results[:accrued].first[:account_id]
+    assert_equal @interest_rule.id, results[:accrued].first[:interest_rule_id]
 
     accrual = InterestAccrual.find_by(account_id: @account.id, accrual_date: @accrual_date)
     assert accrual
     assert accrual.amount_cents.positive?
+    assert_equal @interest_rule.id, accrual.interest_rule_id
   end
 
   test "skips account with zero balance" do
@@ -41,11 +44,27 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
   end
 
   test "skips non-interest-bearing accounts" do
-    DepositAccount.find_by!(account_id: @account.id).update!(interest_bearing: false, interest_rate_basis_points: 0)
+    DepositAccount.find_by!(account_id: @account.id).update!(interest_bearing: false, interest_rate_basis_points: nil)
 
     results = InterestAccrualRunnerService.run!(accrual_date: @accrual_date)
 
     assert_equal 0, results[:accrued].size
+  end
+
+  test "uses product interest rule when deposit account has no rate override" do
+    DepositAccount.find_by!(account_id: @account.id).update!(interest_rate_basis_points: nil)
+
+    results = InterestAccrualRunnerService.run!(accrual_date: @accrual_date)
+
+    assert_equal 10, results[:accrued].first[:amount_cents]
+  end
+
+  test "uses deposit account rate override when present" do
+    DepositAccount.find_by!(account_id: @account.id).update!(interest_rate_basis_points: 730)
+
+    results = InterestAccrualRunnerService.run!(accrual_date: @accrual_date)
+
+    assert_equal 20, results[:accrued].first[:amount_cents]
   end
 
   private
@@ -98,7 +117,7 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
     deposit_account = DepositAccount.find_or_initialize_by(account_id: @account.id)
     deposit_account.deposit_type ||= @account.account_product.default_deposit_type
     deposit_account.interest_bearing = true
-    deposit_account.interest_rate_basis_points = 365 # ~3.65% annual = ~0.01% daily, 100000 cents = $1000 -> ~1 cent/day
+    deposit_account.interest_rate_basis_points = nil
     deposit_account.save!
   end
 

--- a/test/services/interest_accrual_service_test.rb
+++ b/test/services/interest_accrual_service_test.rb
@@ -22,7 +22,8 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
     batch = InterestAccrualService.accrue!(
       account_id: @account.id,
       amount_cents: 150,
-      accrual_date: @accrual_date
+      accrual_date: @accrual_date,
+      interest_rule_id: interest_rules(:now_default).id
     )
 
     assert batch.persisted?
@@ -31,6 +32,7 @@ class InterestAccrualServiceTest < ActiveSupport::TestCase
     assert accrual
     assert_equal 150, accrual.amount_cents
     assert_equal batch.id, accrual.posting_batch_id
+    assert_equal interest_rules(:now_default).id, accrual.interest_rule_id
   end
 
   test "raises when amount is negative" do


### PR DESCRIPTION
## Summary
- Move default deposit interest configuration into product-level `interest_rules` so accrual eligibility and rate selection are driven by the account product.
- Persist the `interest_rule` used for each `interest_accrual` while preserving deposit-account rate overrides for account-specific exceptions.
- Add seed data and coverage for rule activation, override precedence, and accrual traceability.

## Test plan
- [x] `bin/rails db:migrate`
- [x] `bin/rails test test/models/interest_rule_test.rb test/services/interest_accrual_runner_service_test.rb test/services/interest_accrual_service_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

## Linked issue
- Closes #34

## Data / migration impact
- Adds the `interest_rules` table.
- Adds nullable `interest_rule_id` to `interest_accruals` for rule-level traceability.
- Seeds default interest rules for NOW, savings, and CD products.

## Financial risk
- Low to moderate. This changes how default deposit interest rates are sourced, but the posting path remains balanced and continues using the existing product-aware interest expense GL routing.
- Account-level `interest_rate_basis_points` overrides still take precedence when present.

## Rollback notes
- Revert this branch and roll back migration `20260309060000` if the rule-driven accrual selection needs to be removed.

Made with [Cursor](https://cursor.com)