### PR TITLE
Add cadence-driven interest posting

### DIFF
--- a/app/jobs/interest_posting_job.rb
+++ b/app/jobs/interest_posting_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class InterestPostingJob < ApplicationJob
+  queue_as :default
+
+  # Runs due interest posting for eligible accounts based on product cadence.
+  def perform(business_date: nil)
+    results = InterestPostingRunnerService.run!(business_date: business_date)
+
+    Rails.logger.info(
+      "[InterestPostingJob] business_date=#{business_date || BusinessDateService.current} " \
+      "posted=#{results[:posted].size} skipped=#{results[:skipped].size} errors=#{results[:errors].size}"
+    )
+
+    results
+  end
+end

--- a/app/models/interest_accrual.rb
+++ b/app/models/interest_accrual.rb
@@ -6,8 +6,11 @@ class InterestAccrual < ApplicationRecord
   belongs_to :account
   belongs_to :interest_rule, optional: true
   belongs_to :posting_batch, optional: true
+  has_one :interest_posting_application, dependent: :restrict_with_error
 
   validates :accrual_date, presence: true
   validates :amount_cents, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::POSTING_STATUSES }
+
+  scope :unposted, -> { where.missing(:interest_posting_application) }
 end

--- a/app/models/interest_posting_application.rb
+++ b/app/models/interest_posting_application.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class InterestPostingApplication < ApplicationRecord
+  belongs_to :interest_accrual
+  belongs_to :posting_batch
+
+  validates :posted_on, presence: true
+end

--- a/app/models/posting_batch.rb
+++ b/app/models/posting_batch.rb
@@ -10,6 +10,7 @@ class PostingBatch < ApplicationRecord
   has_many :journal_entries, dependent: :destroy
   has_many :fee_assessments
   has_many :interest_accruals
+  has_many :interest_posting_applications, dependent: :restrict_with_error
   has_one :reversal_batch, class_name: "PostingBatch", foreign_key: :reversal_of_batch_id
 
   validates :status, presence: true, inclusion: { in: Bankcore::Enums::POSTING_STATUSES }

--- a/app/services/interest_posting_runner_service.rb
+++ b/app/services/interest_posting_runner_service.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+class InterestPostingRunnerService
+  def self.run!(business_date: nil)
+    new(business_date: business_date).run!
+  end
+
+  def initialize(business_date: nil)
+    @business_date = business_date || BusinessDateService.current
+  end
+
+  def run!
+    results = { posted: [], skipped: [], errors: [] }
+
+    eligible_accounts.find_each do |account|
+      result = post_account_interest(account)
+      results[result[:status]] << result
+    end
+
+    results
+  end
+
+  private
+
+  def eligible_accounts
+    return Account.none if active_rules_by_product.empty?
+
+    Account
+      .includes(:account_product, :deposit_account)
+      .joins(:deposit_account)
+      .where(status: Bankcore::Enums::STATUS_ACTIVE, account_product_id: active_rules_by_product.keys)
+      .where(deposit_accounts: { interest_bearing: true })
+  end
+
+  def post_account_interest(account)
+    interest_rule = active_rules_by_product[account.account_product_id]
+    return { status: :skipped, account_id: account.id, reason: "no_rule" } unless interest_rule
+    return { status: :skipped, account_id: account.id, reason: "cadence_not_due" } unless cadence_due?(interest_rule)
+
+    accruals = unposted_accruals_for(account)
+    return { status: :skipped, account_id: account.id, reason: "no_unposted_accruals" } if accruals.empty?
+
+    amount_cents = accruals.sum(&:amount_cents)
+    return { status: :skipped, account_id: account.id, reason: "zero_amount" } if amount_cents <= 0
+
+    batch = ActiveRecord::Base.transaction do
+      posting_batch = InterestPostingService.post!(
+        account_id: account.id,
+        amount_cents: amount_cents,
+        business_date: @business_date,
+        idempotency_key: idempotency_key(account.id),
+        idempotency_context: {
+          service: "interest_posting_runner",
+          cutoff_date: @business_date,
+          accrual_count: accruals.size
+        }
+      )
+
+      create_posting_links!(accruals, posting_batch)
+      posting_batch
+    end
+
+    {
+      status: :posted,
+      account_id: account.id,
+      amount_cents: amount_cents,
+      accrual_count: accruals.size,
+      posting_batch_id: batch.id
+    }
+  rescue StandardError => e
+    { status: :errors, account_id: account.id, error: e.message }
+  end
+
+  def active_rules_by_product
+    @active_rules_by_product ||= InterestRule
+      .active_on(@business_date)
+      .ordered
+      .each_with_object({}) do |interest_rule, result|
+        result[interest_rule.account_product_id] ||= interest_rule
+      end
+  end
+
+  def cadence_due?(interest_rule)
+    month_end = @business_date == @business_date.end_of_month
+    return false unless month_end
+
+    case interest_rule.posting_cadence
+    when InterestRule::POSTING_CADENCE_QUARTERLY
+      [ 3, 6, 9, 12 ].include?(@business_date.month)
+    when InterestRule::POSTING_CADENCE_ANNUAL
+      @business_date.month == 12
+    else
+      true
+    end
+  end
+
+  def unposted_accruals_for(account)
+    InterestAccrual
+      .unposted
+      .where(account_id: account.id, status: Bankcore::Enums::STATUS_POSTED)
+      .where("accrual_date <= ?", @business_date)
+      .order(:accrual_date, :id)
+      .to_a
+  end
+
+  def create_posting_links!(accruals, batch)
+    accruals.each do |accrual|
+      InterestPostingApplication.find_or_create_by!(interest_accrual: accrual) do |application|
+        application.posting_batch = batch
+        application.posted_on = @business_date
+      end
+    end
+  end
+
+  def idempotency_key(account_id)
+    "int-post-#{account_id}-#{@business_date}"
+  end
+end

--- a/app/services/interest_posting_service.rb
+++ b/app/services/interest_posting_service.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
 class InterestPostingService
-  def self.post!(account_id:, amount_cents:, business_date: nil, idempotency_key: nil)
+  def self.post!(account_id:, amount_cents:, business_date: nil, idempotency_key: nil, idempotency_context: nil)
     new(account_id: account_id, amount_cents: amount_cents, business_date: business_date,
-        idempotency_key: idempotency_key).post!
+        idempotency_key: idempotency_key, idempotency_context: idempotency_context).post!
   end
 
-  def initialize(account_id:, amount_cents:, business_date: nil, idempotency_key: nil)
+  def initialize(account_id:, amount_cents:, business_date: nil, idempotency_key: nil, idempotency_context: nil)
     @account_id = account_id
     @amount_cents = amount_cents
     @business_date = business_date || BusinessDateService.current
     @idempotency_key = idempotency_key
+    @idempotency_context = idempotency_context
   end
 
   def post!
@@ -21,7 +22,8 @@ class InterestPostingService
       account_id: @account_id,
       amount_cents: @amount_cents,
       business_date: @business_date,
-      idempotency_key: @idempotency_key
+      idempotency_key: @idempotency_key,
+      idempotency_context: @idempotency_context
     )
   end
 end

--- a/db/migrate/20260309070000_create_interest_posting_applications.rb
+++ b/db/migrate/20260309070000_create_interest_posting_applications.rb
@@ -1,0 +1,16 @@
+class CreateInterestPostingApplications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :interest_posting_applications do |t|
+      t.references :interest_accrual, null: false, foreign_key: true, index: { unique: true }
+      t.references :posting_batch, null: false, foreign_key: true
+      t.date :posted_on, null: false
+
+      t.timestamps
+    end
+
+    add_index :interest_posting_applications,
+      [ :posting_batch_id, :interest_accrual_id ],
+      unique: true,
+      name: "index_interest_posting_applications_on_batch_and_accrual"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_060000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_070000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -229,6 +229,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_060000) do
     t.index ["account_id"], name: "index_interest_accruals_on_account_id"
     t.index ["interest_rule_id"], name: "index_interest_accruals_on_interest_rule_id"
     t.index ["posting_batch_id"], name: "index_interest_accruals_on_posting_batch_id"
+  end
+
+  create_table "interest_posting_applications", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "interest_accrual_id", null: false
+    t.date "posted_on", null: false
+    t.bigint "posting_batch_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["interest_accrual_id"], name: "index_interest_posting_applications_on_interest_accrual_id", unique: true
+    t.index ["posting_batch_id", "interest_accrual_id"], name: "index_interest_posting_applications_on_batch_and_accrual", unique: true
+    t.index ["posting_batch_id"], name: "index_interest_posting_applications_on_posting_batch_id"
   end
 
   create_table "interest_rules", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -454,6 +465,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_060000) do
   add_foreign_key "interest_accruals", "accounts"
   add_foreign_key "interest_accruals", "interest_rules"
   add_foreign_key "interest_accruals", "posting_batches"
+  add_foreign_key "interest_posting_applications", "interest_accruals"
+  add_foreign_key "interest_posting_applications", "posting_batches"
   add_foreign_key "interest_rules", "account_products"
   add_foreign_key "journal_entries", "posting_batches"
   add_foreign_key "journal_entry_lines", "branches"

--- a/test/services/interest_posting_runner_service_test.rb
+++ b/test/services/interest_posting_runner_service_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InterestPostingRunnerServiceTest < ActiveSupport::TestCase
+  def setup
+    @account = accounts(:two)
+    @interest_rule = interest_rules(:savings_default)
+    @business_date = Date.new(2026, 3, 31)
+    ensure_business_date_open!(@business_date)
+    ensure_interest_bearing_deposit!
+    ensure_int_post_template!
+    ensure_zero_balance!
+  end
+
+  test "posts summed unposted accruals when monthly cadence is due" do
+    create_accrual!(Date.new(2026, 3, 29), 10)
+    create_accrual!(Date.new(2026, 3, 30), 15)
+
+    results = InterestPostingRunnerService.run!(business_date: @business_date)
+
+    assert_equal 1, results[:posted].size
+    assert_equal 25, results[:posted].first[:amount_cents]
+    assert_equal 2, results[:posted].first[:accrual_count]
+
+    batch = PostingBatch.find(results[:posted].first[:posting_batch_id])
+    assert_equal "INT_POST", batch.transaction_code
+    assert_equal 2, InterestPostingApplication.where(posting_batch: batch).count
+  end
+
+  test "skips when cadence is not due" do
+    april_date = Date.new(2026, 4, 30)
+    ensure_business_date_open!(april_date)
+    @interest_rule.update!(posting_cadence: InterestRule::POSTING_CADENCE_QUARTERLY)
+    create_accrual!(Date.new(2026, 4, 29), 10)
+
+    results = InterestPostingRunnerService.run!(business_date: april_date)
+
+    assert_equal 0, results[:posted].size
+    assert results[:skipped].any? { |entry| entry[:account_id] == @account.id && entry[:reason] == "cadence_not_due" }
+    assert_equal 0, InterestPostingApplication.count
+  end
+
+  test "skips when no unposted accruals exist" do
+    results = InterestPostingRunnerService.run!(business_date: @business_date)
+
+    assert_equal 0, results[:posted].size
+    assert results[:skipped].any? { |entry| entry[:account_id] == @account.id && entry[:reason] == "no_unposted_accruals" }
+  end
+
+  test "does not repost accruals already linked to an interest posting" do
+    create_accrual!(Date.new(2026, 3, 29), 10)
+    create_accrual!(Date.new(2026, 3, 30), 15)
+
+    first_results = InterestPostingRunnerService.run!(business_date: @business_date)
+    second_results = InterestPostingRunnerService.run!(business_date: @business_date)
+
+    assert_equal 1, first_results[:posted].size
+    assert_equal 0, second_results[:posted].size
+    assert results_include_reason?(second_results[:skipped], "no_unposted_accruals")
+    assert_equal 2, InterestPostingApplication.count
+    assert_equal 1, PostingBatch.where(transaction_code: "INT_POST", business_date: @business_date).count
+  end
+
+  private
+
+  def create_accrual!(accrual_date, amount_cents)
+    InterestAccrual.create!(
+      account: @account,
+      interest_rule: @interest_rule,
+      accrual_date: accrual_date,
+      amount_cents: amount_cents,
+      status: Bankcore::Enums::STATUS_POSTED
+    )
+  end
+
+  def ensure_interest_bearing_deposit!
+    deposit_account = DepositAccount.find_or_initialize_by(account_id: @account.id)
+    deposit_account.deposit_type ||= @account.account_product.default_deposit_type
+    deposit_account.interest_bearing = true
+    deposit_account.save!
+  end
+
+  def ensure_zero_balance!
+    balance = AccountBalance.find_or_initialize_by(account_id: @account.id)
+    balance.posted_balance_cents ||= 0
+    balance.available_balance_cents ||= 0
+    balance.as_of_at ||= Time.current
+    balance.save!
+  end
+
+  def ensure_business_date_open!(date)
+    BusinessDate.find_or_create_by!(business_date: date) do |business_date|
+      business_date.status = Bankcore::Enums::BUSINESS_DATE_OPEN
+      business_date.opened_at = Time.current
+    end
+  end
+
+  def ensure_int_post_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "INT_POST" })
+
+    tc = TransactionCode.find_or_create_by!(code: "INT_POST") do |t|
+      t.description = "Interest posting"
+      t.reversal_code = "INT_POST_REVERSAL"
+      t.active = true
+    end
+    gl_payable = GlAccount.find_or_create_by!(gl_number: "2510") do |g|
+      g.name = "Accrued Interest Payable"
+      g.category = "liability"
+      g.normal_balance = "credit"
+      g.status = Bankcore::Enums::STATUS_ACTIVE
+    end
+    tpl = PostingTemplate.find_or_create_by!(transaction_code_id: tc.id) do |t|
+      t.name = "Interest Posting"
+      t.description = "Debit payable, Credit account"
+      t.active = true
+    end
+    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 0) do |l|
+      l.leg_type = Bankcore::Enums::LEG_TYPE_DEBIT
+      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL
+      l.gl_account_id = gl_payable.id
+      l.description = "Debit interest payable"
+    end
+    PostingTemplateLeg.find_or_create_by!(posting_template_id: tpl.id, position: 1) do |l|
+      l.leg_type = Bankcore::Enums::LEG_TYPE_CREDIT
+      l.account_source = Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER
+      l.description = "Credit customer account"
+    end
+  end
+
+  def results_include_reason?(entries, reason)
+    entries.any? { |entry| entry[:account_id] == @account.id && entry[:reason] == reason }
+  end
+end


### PR DESCRIPTION
## Summary
- Turn `interest_rules.posting_cadence` into operational behavior by adding a runner that releases accrued interest only when the product cadence is due.
- Prevent double-posting without mutating posted accrual rows by linking released accruals to the generated `INT_POST` batch through `interest_posting_applications`.
- Add a scheduled job and focused coverage for cadence due dates, no-accrual skips, and repeat-run idempotency behavior.

## Test plan
- [x] `bin/rails db:migrate`
- [x] `bin/rails test test/services/interest_posting_service_test.rb test/services/interest_posting_runner_service_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

## Linked issue
- Closes #36

## Data / migration impact
- Adds the `interest_posting_applications` table to link posted accrual rows to their `INT_POST` posting batch.
- Updates schema to expose the new interest posting linkage.

## Financial risk
- Low to moderate. This changes when accrued interest is released to customer balances, but preserves the existing balanced posting path through `INT_POST` and avoids mutating posted accrual history.
- Cadence handling currently supports month-end monthly, quarter-end quarterly, and year-end annual releases.

## Rollback notes
- Revert this branch and roll back migration `20260309070000` if cadence-driven interest posting needs to be removed.

Made with [Cursor](https://cursor.com)