### PR TITLE
Add admin management for product rules

### DIFF
--- a/app/controllers/account_products_controller.rb
+++ b/app/controllers/account_products_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class AccountProductsController < ApplicationController
+  before_action :set_account_product, only: %i[show edit update]
+  before_action :set_form_options, only: %i[new create edit update]
+
+  def index
+    @account_products = AccountProduct
+      .includes(:liability_gl_account, :interest_expense_gl_account, :fee_rules, :interest_rules)
+      .order(:name)
+  end
+
+  def show
+    @fee_rules = @account_product.fee_rules.includes(:fee_type, :gl_account).ordered
+    @interest_rules = @account_product.interest_rules.ordered
+  end
+
+  def new
+    @account_product = AccountProduct.new(
+      product_family: "deposit",
+      currency_code: Bankcore::DEFAULT_CURRENCY,
+      statement_cycle: "monthly",
+      status: Bankcore::Enums::STATUS_ACTIVE
+    )
+  end
+
+  def create
+    @account_product = AccountProduct.new(account_product_params)
+    if @account_product.save
+      redirect_to account_product_path(@account_product), notice: "Account product created successfully."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @account_product.update(account_product_params)
+      redirect_to account_product_path(@account_product), notice: "Account product updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_account_product
+    @account_product = AccountProduct.find(params[:id])
+  end
+
+  def set_form_options
+    @gl_accounts = GlAccount.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:gl_number)
+  end
+
+  def account_product_params
+    params.require(:account_product).permit(
+      :product_code,
+      :name,
+      :product_family,
+      :currency_code,
+      :statement_cycle,
+      :allow_overdraft,
+      :liability_gl_account_id,
+      :asset_gl_account_id,
+      :interest_expense_gl_account_id,
+      :status
+    )
+  end
+end

--- a/app/controllers/fee_rules_controller.rb
+++ b/app/controllers/fee_rules_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class FeeRulesController < ApplicationController
+  before_action :set_account_product, only: %i[new create]
+  before_action :set_fee_rule, only: %i[edit update]
+  before_action :set_form_options, only: %i[new create edit update]
+
+  def new
+    @fee_rule = @account_product.fee_rules.new(
+      method: FeeRule::METHOD_FIXED_AMOUNT,
+      priority: next_priority(@account_product)
+    )
+  end
+
+  def create
+    @fee_rule = @account_product.fee_rules.new(fee_rule_params)
+    if @fee_rule.save
+      redirect_to account_product_path(@account_product), notice: "Fee rule created successfully."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @fee_rule.update(fee_rule_params)
+      redirect_to account_product_path(@fee_rule.account_product), notice: "Fee rule updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_account_product
+    @account_product = AccountProduct.find(params[:account_product_id])
+  end
+
+  def set_fee_rule
+    @fee_rule = FeeRule.find(params[:id])
+    @account_product = @fee_rule.account_product
+  end
+
+  def set_form_options
+    @fee_types = FeeType.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:name)
+    @gl_accounts = GlAccount.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:gl_number)
+  end
+
+  def fee_rule_params
+    params.require(:fee_rule).permit(
+      :fee_type_id,
+      :priority,
+      :method,
+      :amount_cents,
+      :gl_account_id,
+      :effective_on,
+      :ends_on
+    )
+  end
+
+  def next_priority(account_product)
+    account_product.fee_rules.maximum(:priority).to_i + 100
+  end
+end

--- a/app/controllers/interest_rules_controller.rb
+++ b/app/controllers/interest_rules_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class InterestRulesController < ApplicationController
+  before_action :set_account_product, only: %i[new create]
+  before_action :set_interest_rule, only: %i[edit update]
+
+  def new
+    @interest_rule = @account_product.interest_rules.new(
+      day_count_method: InterestRule::DAY_COUNT_METHOD_ACTUAL_365,
+      posting_cadence: InterestRule::POSTING_CADENCE_MONTHLY
+    )
+  end
+
+  def create
+    @interest_rule = @account_product.interest_rules.new(interest_rule_params)
+    if @interest_rule.save
+      redirect_to account_product_path(@account_product), notice: "Interest rule created successfully."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @interest_rule.update(interest_rule_params)
+      redirect_to account_product_path(@interest_rule.account_product), notice: "Interest rule updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_account_product
+    @account_product = AccountProduct.find(params[:account_product_id])
+  end
+
+  def set_interest_rule
+    @interest_rule = InterestRule.find(params[:id])
+    @account_product = @interest_rule.account_product
+  end
+
+  def interest_rule_params
+    params.require(:interest_rule).permit(
+      :rate,
+      :day_count_method,
+      :posting_cadence,
+      :effective_on,
+      :ends_on
+    )
+  end
+end

--- a/app/views/account_products/_form.html.erb
+++ b/app/views/account_products/_form.html.erb
@@ -1,0 +1,90 @@
+<%= form_with model: @account_product, local: true, class: "space-y-4" do |f| %>
+  <% if @account_product.errors.any? %>
+    <div class="alert alert-error mb-4">
+      <ul class="list-disc list-inside">
+        <% @account_product.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="grid gap-4 lg:grid-cols-2">
+    <div class="form-control w-full">
+      <label class="label" for="account_product_product_code">
+        <span class="label-text">Product Code</span>
+      </label>
+      <%= f.text_field :product_code, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_name">
+        <span class="label-text">Name</span>
+      </label>
+      <%= f.text_field :name, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_product_family">
+        <span class="label-text">Product Family</span>
+      </label>
+      <%= f.text_field :product_family, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_currency_code">
+        <span class="label-text">Currency</span>
+      </label>
+      <%= f.text_field :currency_code, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_statement_cycle">
+        <span class="label-text">Statement Cycle</span>
+      </label>
+      <%= f.select :statement_cycle, AccountProduct::STATEMENT_CYCLES.map { |value| [value.titleize, value] }, {}, class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_status">
+        <span class="label-text">Status</span>
+      </label>
+      <%= f.select :status, Bankcore::Enums::STATUSES.map { |value| [value.titleize, value] }, {}, class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label cursor-pointer justify-start gap-3" for="account_product_allow_overdraft">
+        <%= f.check_box :allow_overdraft, class: "checkbox checkbox-primary" %>
+        <span class="label-text">Allow overdraft by default</span>
+      </label>
+    </div>
+  </div>
+
+  <div class="grid gap-4 lg:grid-cols-3">
+    <div class="form-control w-full">
+      <label class="label" for="account_product_liability_gl_account_id">
+        <span class="label-text">Liability GL</span>
+      </label>
+      <%= f.collection_select :liability_gl_account_id, @gl_accounts, :id, :name, { include_blank: "— None —" }, class: "select select-bordered w-full" %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_asset_gl_account_id">
+        <span class="label-text">Asset GL</span>
+      </label>
+      <%= f.collection_select :asset_gl_account_id, @gl_accounts, :id, :name, { include_blank: "— None —" }, class: "select select-bordered w-full" %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="account_product_interest_expense_gl_account_id">
+        <span class="label-text">Interest Expense GL</span>
+      </label>
+      <%= f.collection_select :interest_expense_gl_account_id, @gl_accounts, :id, :name, { include_blank: "— None —" }, class: "select select-bordered w-full" %>
+    </div>
+  </div>
+
+  <div class="flex gap-2 pt-4">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", @account_product.persisted? ? account_product_path(@account_product) : account_products_path, class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/account_products/edit.html.erb
+++ b/app/views/account_products/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Edit #{@account_product.name} - BankCORE" %>
+
+<div class="w-full max-w-5xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Product", account_product_path(@account_product), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Edit Account Product</h1>
+      <p class="workspace-subtitle">Update product defaults and GL mappings without changing posted financial history.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/account_products/index.html.erb
+++ b/app/views/account_products/index.html.erb
@@ -1,0 +1,73 @@
+<% content_for :title, "Account Products - BankCORE" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back", root_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Account Products</h1>
+      <p class="workspace-subtitle">Manage product-level deposit behavior, GL mappings, and the fee and interest rules that drive automated processing.</p>
+    </div>
+    <%= link_to "New Product", new_account_product_path, class: "btn btn-primary" %>
+  </div>
+
+  <div class="grid gap-4 lg:grid-cols-4 mb-6">
+    <div class="ui-metric">
+      <div class="ui-metric-label">Products</div>
+      <div class="ui-metric-value ui-mono"><%= @account_products.size %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Active</div>
+      <div class="ui-metric-value ui-mono"><%= @account_products.count { |product| product.status == Bankcore::Enums::STATUS_ACTIVE } %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Fee Rules</div>
+      <div class="ui-metric-value ui-mono"><%= @account_products.sum { |product| product.fee_rules.size } %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Interest Rules</div>
+      <div class="ui-metric-value ui-mono"><%= @account_products.sum { |product| product.interest_rules.size } %></div>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Product Catalog</h2>
+        <p class="mt-1 text-sm text-base-content/65">Configured products with GL ownership and rule coverage.</p>
+      </div>
+    </div>
+    <div class="ui-panel-body">
+      <table class="ui-ledger-table">
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Family</th>
+            <th>Currency</th>
+            <th>Liability GL</th>
+            <th>Interest GL</th>
+            <th>Rules</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @account_products.each do |product| %>
+            <tr>
+              <td>
+                <div class="font-medium"><%= product.name %></div>
+                <div class="ui-mono text-xs text-base-content/60"><%= product.product_code %></div>
+              </td>
+              <td><%= product.product_family %></td>
+              <td class="ui-mono"><%= product.currency_code %></td>
+              <td class="ui-mono"><%= product.liability_gl_account&.gl_number || "—" %></td>
+              <td class="ui-mono"><%= product.interest_expense_gl_account&.gl_number || "—" %></td>
+              <td class="ui-mono"><%= "#{product.fee_rules.size} / #{product.interest_rules.size}" %></td>
+              <td><span class="<%= status_pill_class(product.status) %>"><%= product.status %></span></td>
+              <td><%= link_to "View", account_product_path(product), class: "btn btn-ghost btn-sm" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/app/views/account_products/new.html.erb
+++ b/app/views/account_products/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "New Account Product - BankCORE" %>
+
+<div class="w-full max-w-5xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Products", account_products_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">New Account Product</h1>
+      <p class="workspace-subtitle">Create a product definition that can drive account defaults, GL routing, and rule-based automation.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/account_products/show.html.erb
+++ b/app/views/account_products/show.html.erb
@@ -1,0 +1,141 @@
+<% content_for :title, "#{@account_product.name} - BankCORE" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Products", account_products_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Product Configuration</h1>
+      <p class="workspace-subtitle">Review product defaults, GL ownership, and active fee and interest rules for this account product.</p>
+    </div>
+    <%= link_to "Edit Product", edit_account_product_path(@account_product), class: "btn btn-primary" %>
+  </div>
+
+  <div class="grid gap-4 lg:grid-cols-4 mb-6">
+    <div class="ui-metric">
+      <div class="ui-metric-label">Product Code</div>
+      <div class="ui-metric-value ui-mono"><%= @account_product.product_code %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Statement Cycle</div>
+      <div class="ui-metric-value"><%= @account_product.statement_cycle %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Fee Rules</div>
+      <div class="ui-metric-value ui-mono"><%= @fee_rules.size %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Interest Rules</div>
+      <div class="ui-metric-value ui-mono"><%= @interest_rules.size %></div>
+    </div>
+  </div>
+
+  <section class="ui-panel mb-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Core Product Settings</h2>
+        <p class="mt-1 text-sm text-base-content/65">Primary configuration values used by account creation and posting resolution.</p>
+      </div>
+    </div>
+    <div class="ui-panel-body">
+      <div class="grid gap-4 lg:grid-cols-3">
+        <div class="space-y-3 rounded-lg border border-base-300 bg-base-100 p-4">
+          <div class="ui-kv-row"><div class="ui-kv-label">Name</div><div class="ui-kv-value"><%= @account_product.name %></div></div>
+          <div class="ui-kv-row"><div class="ui-kv-label">Family</div><div class="ui-kv-value"><%= @account_product.product_family %></div></div>
+          <div class="ui-kv-row"><div class="ui-kv-label">Currency</div><div class="ui-kv-value ui-mono"><%= @account_product.currency_code %></div></div>
+        </div>
+        <div class="space-y-3 rounded-lg border border-base-300 bg-base-100 p-4">
+          <div class="ui-kv-row"><div class="ui-kv-label">Liability GL</div><div class="ui-kv-value ui-mono"><%= @account_product.liability_gl_account&.gl_number || "—" %></div></div>
+          <div class="ui-kv-row"><div class="ui-kv-label">Asset GL</div><div class="ui-kv-value ui-mono"><%= @account_product.asset_gl_account&.gl_number || "—" %></div></div>
+          <div class="ui-kv-row"><div class="ui-kv-label">Interest Expense GL</div><div class="ui-kv-value ui-mono"><%= @account_product.interest_expense_gl_account&.gl_number || "—" %></div></div>
+        </div>
+        <div class="space-y-3 rounded-lg border border-base-300 bg-base-100 p-4">
+          <div class="ui-kv-row"><div class="ui-kv-label">Deposit Product</div><div class="ui-kv-value"><%= @account_product.deposit_product? ? "Yes" : "No" %></div></div>
+          <div class="ui-kv-row"><div class="ui-kv-label">Default Overdraft</div><div class="ui-kv-value"><%= @account_product.default_overdraft_policy || "—" %></div></div>
+          <div class="ui-kv-row"><div class="ui-kv-label">Status</div><div class="ui-kv-value"><span class="<%= status_pill_class(@account_product.status) %>"><%= @account_product.status %></span></div></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="ui-panel mb-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Fee Rules</h2>
+        <p class="mt-1 text-sm text-base-content/65">Rule-driven fee eligibility and optional amount or GL overrides for this product.</p>
+      </div>
+      <%= link_to "New Fee Rule", new_account_product_fee_rule_path(@account_product), class: "btn btn-outline btn-sm" %>
+    </div>
+    <div class="ui-panel-body">
+      <% if @fee_rules.any? %>
+        <table class="ui-ledger-table">
+          <thead>
+            <tr>
+              <th>Fee Type</th>
+              <th>Priority</th>
+              <th>Amount</th>
+              <th>GL Override</th>
+              <th>Effective</th>
+              <th>Ends</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @fee_rules.each do |fee_rule| %>
+              <tr>
+                <td><%= fee_rule.fee_type.name %></td>
+                <td class="ui-mono"><%= fee_rule.priority %></td>
+                <td class="ui-mono"><%= number_to_currency(fee_rule.amount_cents_for_assessment / 100.0) %></td>
+                <td class="ui-mono"><%= fee_rule.gl_account&.gl_number || "Default" %></td>
+                <td class="ui-mono"><%= fee_rule.effective_on&.strftime("%Y-%m-%d") || "—" %></td>
+                <td class="ui-mono"><%= fee_rule.ends_on&.strftime("%Y-%m-%d") || "—" %></td>
+                <td><%= link_to "Edit", edit_fee_rule_path(fee_rule), class: "btn btn-ghost btn-sm" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-sm text-base-content/60">No fee rules configured for this product yet.</p>
+      <% end %>
+    </div>
+  </section>
+
+  <section class="ui-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Interest Rules</h2>
+        <p class="mt-1 text-sm text-base-content/65">Default accrual rate, day count method, and posting cadence used for interest-bearing accounts on this product.</p>
+      </div>
+      <%= link_to "New Interest Rule", new_account_product_interest_rule_path(@account_product), class: "btn btn-outline btn-sm" %>
+    </div>
+    <div class="ui-panel-body">
+      <% if @interest_rules.any? %>
+        <table class="ui-ledger-table">
+          <thead>
+            <tr>
+              <th>Rate</th>
+              <th>Day Count</th>
+              <th>Cadence</th>
+              <th>Effective</th>
+              <th>Ends</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @interest_rules.each do |interest_rule| %>
+              <tr>
+                <td class="ui-mono"><%= number_to_percentage(interest_rule.rate.to_f * 100, precision: 3, strip_insignificant_zeros: true) %></td>
+                <td><%= interest_rule.day_count_method %></td>
+                <td><%= interest_rule.posting_cadence %></td>
+                <td class="ui-mono"><%= interest_rule.effective_on&.strftime("%Y-%m-%d") || "—" %></td>
+                <td class="ui-mono"><%= interest_rule.ends_on&.strftime("%Y-%m-%d") || "—" %></td>
+                <td><%= link_to "Edit", edit_interest_rule_path(interest_rule), class: "btn btn-ghost btn-sm" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-sm text-base-content/60">No interest rules configured for this product yet.</p>
+      <% end %>
+    </div>
+  </section>
+</div>

--- a/app/views/fee_rules/_form.html.erb
+++ b/app/views/fee_rules/_form.html.erb
@@ -1,0 +1,68 @@
+<%= form_with model: (@fee_rule.persisted? ? @fee_rule : [@account_product, @fee_rule]), local: true, class: "space-y-4" do |f| %>
+  <% if @fee_rule.errors.any? %>
+    <div class="alert alert-error mb-4">
+      <ul class="list-disc list-inside">
+        <% @fee_rule.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="grid gap-4 lg:grid-cols-2">
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_fee_type_id">
+        <span class="label-text">Fee Type</span>
+      </label>
+      <%= f.collection_select :fee_type_id, @fee_types, :id, :name, { include_blank: "— Select fee type —" }, class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_priority">
+        <span class="label-text">Priority</span>
+      </label>
+      <%= f.number_field :priority, class: "input input-bordered w-full", min: 1, required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_method">
+        <span class="label-text">Method</span>
+      </label>
+      <%= f.select :method, FeeRule::METHODS.map { |value| [value.titleize, value] }, {}, class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_amount_cents">
+        <span class="label-text">Amount Override (cents)</span>
+      </label>
+      <%= f.number_field :amount_cents, class: "input input-bordered w-full", min: 1 %>
+      <label class="label"><span class="label-text-alt">Leave blank to use the fee type default amount.</span></label>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_gl_account_id">
+        <span class="label-text">GL Override</span>
+      </label>
+      <%= f.collection_select :gl_account_id, @gl_accounts, :id, :name, { include_blank: "— Use fee type default —" }, class: "select select-bordered w-full" %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_effective_on">
+        <span class="label-text">Effective On</span>
+      </label>
+      <%= f.date_field :effective_on, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_rule_ends_on">
+        <span class="label-text">Ends On</span>
+      </label>
+      <%= f.date_field :ends_on, class: "input input-bordered w-full" %>
+    </div>
+  </div>
+
+  <div class="flex gap-2 pt-4">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", account_product_path(@account_product), class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/fee_rules/edit.html.erb
+++ b/app/views/fee_rules/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Edit Fee Rule - BankCORE" %>
+
+<div class="w-full max-w-5xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Product", account_product_path(@account_product), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Edit Fee Rule</h1>
+      <p class="workspace-subtitle">Update fee behavior for <%= @account_product.name %> while preserving prior assessed postings.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/fee_rules/new.html.erb
+++ b/app/views/fee_rules/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "New Fee Rule - BankCORE" %>
+
+<div class="w-full max-w-5xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Product", account_product_path(@account_product), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">New Fee Rule</h1>
+      <p class="workspace-subtitle">Configure fee eligibility and optional posting overrides for <%= @account_product.name %>.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/interest_rules/_form.html.erb
+++ b/app/views/interest_rules/_form.html.erb
@@ -1,0 +1,54 @@
+<%= form_with model: (@interest_rule.persisted? ? @interest_rule : [@account_product, @interest_rule]), local: true, class: "space-y-4" do |f| %>
+  <% if @interest_rule.errors.any? %>
+    <div class="alert alert-error mb-4">
+      <ul class="list-disc list-inside">
+        <% @interest_rule.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="grid gap-4 lg:grid-cols-2">
+    <div class="form-control w-full">
+      <label class="label" for="interest_rule_rate">
+        <span class="label-text">Annual Rate</span>
+      </label>
+      <%= f.number_field :rate, class: "input input-bordered w-full", step: "0.000001", min: "0.000001", required: true %>
+      <label class="label"><span class="label-text-alt">Store rates as decimal values such as <span class="ui-mono">0.0200</span> for 2.00%.</span></label>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="interest_rule_day_count_method">
+        <span class="label-text">Day Count Method</span>
+      </label>
+      <%= f.select :day_count_method, InterestRule::DAY_COUNT_METHODS.map { |value| [value, value] }, {}, class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="interest_rule_posting_cadence">
+        <span class="label-text">Posting Cadence</span>
+      </label>
+      <%= f.select :posting_cadence, InterestRule::POSTING_CADENCES.map { |value| [value.titleize, value] }, {}, class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="interest_rule_effective_on">
+        <span class="label-text">Effective On</span>
+      </label>
+      <%= f.date_field :effective_on, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="interest_rule_ends_on">
+        <span class="label-text">Ends On</span>
+      </label>
+      <%= f.date_field :ends_on, class: "input input-bordered w-full" %>
+    </div>
+  </div>
+
+  <div class="flex gap-2 pt-4">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", account_product_path(@account_product), class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/interest_rules/edit.html.erb
+++ b/app/views/interest_rules/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Edit Interest Rule - BankCORE" %>
+
+<div class="w-full max-w-5xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Product", account_product_path(@account_product), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Edit Interest Rule</h1>
+      <p class="workspace-subtitle">Update default interest behavior for <%= @account_product.name %> without changing posted accrual history.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/interest_rules/new.html.erb
+++ b/app/views/interest_rules/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "New Interest Rule - BankCORE" %>
+
+<div class="w-full max-w-5xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Product", account_product_path(@account_product), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">New Interest Rule</h1>
+      <p class="workspace-subtitle">Configure default rate and cadence behavior for <%= @account_product.name %>.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,9 @@
 
             <div class="app-sidebar-section">
               <div class="app-sidebar-label">Back Office Review</div>
+              <%= link_to account_products_path, class: app_nav_link_class(account_products_path) do %>
+                <span>Account Products</span>
+              <% end %>
               <%= link_to gl_accounts_path, class: app_nav_link_class(gl_accounts_path) do %>
                 <span>GL Accounts</span>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,12 @@ Rails.application.routes.draw do
     resources :account_holds, only: %i[new create], shallow: true
     resources :account_owners, only: %i[new create], shallow: true
   end
+  resources :account_products, only: %i[index show new create edit update] do
+    resources :fee_rules, only: %i[new create]
+    resources :interest_rules, only: %i[new create]
+  end
+  resources :fee_rules, only: %i[edit update]
+  resources :interest_rules, only: %i[edit update]
   post "account_holds/:id/release", to: "account_holds#release", as: :release_account_hold
 
   resources :business_dates, only: %i[index show] do

--- a/test/controllers/account_products_controller_test.rb
+++ b/test/controllers/account_products_controller_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AccountProductsControllerTest < ActionDispatch::IntegrationTest
+  test "index renders" do
+    get account_products_url
+
+    assert_response :success
+    assert_select "h1", text: /Account Products/
+    assert_select "a", text: "New Product"
+  end
+
+  test "show renders product configuration" do
+    get account_product_url(account_products(:savings))
+
+    assert_response :success
+    assert_select "h1", text: /Product Configuration/
+    assert_select "a", text: "New Fee Rule"
+    assert_select "a", text: "New Interest Rule"
+  end
+
+  test "create creates account product and redirects" do
+    assert_difference "AccountProduct.count", 1 do
+      post account_products_url, params: {
+        account_product: {
+          product_code: "checking_plus",
+          name: "Checking Plus",
+          product_family: "deposit",
+          currency_code: "USD",
+          statement_cycle: "monthly",
+          allow_overdraft: true,
+          liability_gl_account_id: gl_accounts(:six).id,
+          status: Bankcore::Enums::STATUS_ACTIVE
+        }
+      }
+    end
+
+    account_product = AccountProduct.order(:id).last
+    assert_redirected_to account_product_path(account_product)
+    assert_equal "checking_plus", account_product.product_code
+    assert_equal gl_accounts(:six).id, account_product.liability_gl_account_id
+  end
+
+  test "update modifies account product and redirects" do
+    patch account_product_url(account_products(:dda)), params: {
+      account_product: {
+        name: "Updated DDA",
+        product_family: "deposit",
+        currency_code: "USD",
+        statement_cycle: "quarterly",
+        allow_overdraft: false,
+        liability_gl_account_id: gl_accounts(:six).id,
+        asset_gl_account_id: "",
+        interest_expense_gl_account_id: "",
+        status: Bankcore::Enums::STATUS_ACTIVE
+      }
+    }
+
+    assert_redirected_to account_product_path(account_products(:dda))
+    assert_equal "Updated DDA", account_products(:dda).reload.name
+    assert_equal "quarterly", account_products(:dda).statement_cycle
+  end
+end

--- a/test/controllers/fee_rules_controller_test.rb
+++ b/test/controllers/fee_rules_controller_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FeeRulesControllerTest < ActionDispatch::IntegrationTest
+  test "new renders fee rule form" do
+    get new_account_product_fee_rule_url(account_products(:dda))
+
+    assert_response :success
+    assert_select "form"
+    assert_select "select[name='fee_rule[fee_type_id]']"
+    assert_select "input[name='fee_rule[priority]']"
+  end
+
+  test "create creates fee rule and redirects" do
+    product = account_products(:now)
+
+    assert_difference "FeeRule.count", 1 do
+      post account_product_fee_rules_url(product), params: {
+        fee_rule: {
+          fee_type_id: fee_types(:maintenance).id,
+          priority: 200,
+          method: FeeRule::METHOD_FIXED_AMOUNT,
+          amount_cents: 2500,
+          gl_account_id: gl_accounts(:ten).id,
+          effective_on: Date.new(2026, 4, 1)
+        }
+      }
+    end
+
+    fee_rule = FeeRule.order(:id).last
+    assert_redirected_to account_product_path(product)
+    assert_equal product.id, fee_rule.account_product_id
+    assert_equal 2500, fee_rule.amount_cents
+  end
+
+  test "update modifies fee rule and redirects" do
+    patch fee_rule_url(fee_rules(:maintenance_dda)), params: {
+      fee_rule: {
+        fee_type_id: fee_types(:maintenance).id,
+        priority: 150,
+        method: FeeRule::METHOD_FIXED_AMOUNT,
+        amount_cents: 1750,
+        gl_account_id: "",
+        effective_on: Date.new(2026, 3, 1),
+        ends_on: Date.new(2026, 12, 31)
+      }
+    }
+
+    assert_redirected_to account_product_path(account_products(:dda))
+    fee_rule = fee_rules(:maintenance_dda).reload
+    assert_equal 150, fee_rule.priority
+    assert_equal 1750, fee_rule.amount_cents
+    assert_equal Date.new(2026, 12, 31), fee_rule.ends_on
+  end
+end

--- a/test/controllers/interest_rules_controller_test.rb
+++ b/test/controllers/interest_rules_controller_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InterestRulesControllerTest < ActionDispatch::IntegrationTest
+  test "new renders interest rule form" do
+    get new_account_product_interest_rule_url(account_products(:savings))
+
+    assert_response :success
+    assert_select "form"
+    assert_select "input[name='interest_rule[rate]']"
+    assert_select "select[name='interest_rule[posting_cadence]']"
+  end
+
+  test "create creates interest rule and redirects" do
+    product = account_products(:now)
+
+    assert_difference "InterestRule.count", 1 do
+      post account_product_interest_rules_url(product), params: {
+        interest_rule: {
+          rate: "0.015000",
+          day_count_method: InterestRule::DAY_COUNT_METHOD_ACTUAL_365,
+          posting_cadence: InterestRule::POSTING_CADENCE_MONTHLY,
+          effective_on: Date.new(2026, 4, 1)
+        }
+      }
+    end
+
+    interest_rule = InterestRule.order(:id).last
+    assert_redirected_to account_product_path(product)
+    assert_equal product.id, interest_rule.account_product_id
+    assert_equal BigDecimal("0.015"), interest_rule.rate
+  end
+
+  test "update modifies interest rule and redirects" do
+    patch interest_rule_url(interest_rules(:savings_default)), params: {
+      interest_rule: {
+        rate: "0.025000",
+        day_count_method: InterestRule::DAY_COUNT_METHOD_30_360,
+        posting_cadence: InterestRule::POSTING_CADENCE_QUARTERLY,
+        effective_on: Date.new(2026, 3, 1),
+        ends_on: Date.new(2026, 12, 31)
+      }
+    }
+
+    assert_redirected_to account_product_path(account_products(:savings))
+    interest_rule = interest_rules(:savings_default).reload
+    assert_equal BigDecimal("0.025"), interest_rule.rate
+    assert_equal InterestRule::DAY_COUNT_METHOD_30_360, interest_rule.day_count_method
+    assert_equal InterestRule::POSTING_CADENCE_QUARTERLY, interest_rule.posting_cadence
+  end
+end


### PR DESCRIPTION
## Summary
- Add an internal `Account Products` workstation area with create, review, and update flows for product-level GL and operational defaults.
- Add nested management flows for `fee_rules` and `interest_rules` so operations can maintain product behavior without relying on seeds.
- Extend navigation and controller coverage so product configuration is editable through the app while preserving existing financial invariants.

## Test plan
- [x] `bin/rails test test/controllers/account_products_controller_test.rb test/controllers/fee_rules_controller_test.rb test/controllers/interest_rules_controller_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

## Linked issue
- Closes #38

## Data / migration impact
- No schema changes.
- Moves product/rule maintenance from seed-only setup to application-managed forms.

## Financial risk
- Low to moderate. This changes configuration entry points, not posting engine behavior, but invalid product or rule edits could affect future operational processing.
- Existing validations on `account_products`, `fee_rules`, and `interest_rules` remain in place.

## Rollback notes
- Revert this branch if the admin configuration surface needs to be removed.

Made with [Cursor](https://cursor.com)