### PR TITLE
Add structured transaction references

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -19,13 +19,14 @@ class TransactionsController < ApplicationController
 
   def index
     @transactions = BankingTransaction
-      .includes(:branch, :posting_batch)
+      .includes(:branch, :posting_batch, :transaction_references)
       .order(created_at: :desc)
       .limit(100)
   end
 
   def show
     @posting_batch = @transaction.posting_batch
+    @transaction_references = @transaction.transaction_references.order(:reference_type, :id)
     @posting_legs = @posting_batch&.posting_legs&.includes(:account, :gl_account) || []
   end
 

--- a/app/models/banking_transaction.rb
+++ b/app/models/banking_transaction.rb
@@ -8,6 +8,7 @@ class BankingTransaction < ApplicationRecord
   belongs_to :branch
   belongs_to :created_by, class_name: "User", optional: true
   has_many :account_transactions, foreign_key: :transaction_id, dependent: :nullify
+  has_many :transaction_references, foreign_key: :transaction_id, dependent: :restrict_with_error
   has_one :posting_batch, foreign_key: :operational_transaction_id
 
   validates :transaction_type, presence: true

--- a/app/models/transaction_reference.rb
+++ b/app/models/transaction_reference.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TransactionReference < ApplicationRecord
+  REFERENCE_TYPE_REFERENCE_NUMBER = "reference_number"
+  REFERENCE_TYPE_EXTERNAL_REFERENCE = "external_reference"
+  REFERENCE_TYPE_IDEMPOTENCY_KEY = "idempotency_key"
+
+  belongs_to :operational_transaction, class_name: "BankingTransaction", foreign_key: :transaction_id
+
+  validates :reference_type, presence: true
+  validates :reference_value, presence: true
+  validates :reference_value, uniqueness: { scope: [ :transaction_id, :reference_type ] }
+end

--- a/app/services/posting_engine.rb
+++ b/app/services/posting_engine.rb
@@ -166,6 +166,7 @@ class PostingEngine
 
     JournalProjector.project!(posting_batch: batch)
     AccountProjector.project!(posting_batch: batch)
+    persist_transaction_references!(operational_txn: operational_txn, batch: batch)
 
     AuditEmissionService.emit!(
       event_type: AuditEmissionService::EVENT_POSTING_COMMITTED,
@@ -180,6 +181,16 @@ class PostingEngine
     )
 
     batch
+  end
+
+  def persist_transaction_references!(operational_txn:, batch:)
+    reference_attributes(batch).each do |reference_type, reference_value|
+      TransactionReference.find_or_create_by!(
+        operational_transaction: operational_txn,
+        reference_type: reference_type,
+        reference_value: reference_value
+      )
+    end
   end
 
   def resolve_branch_id
@@ -209,6 +220,14 @@ class PostingEngine
 
   def idempotency_payload_json
     @idempotency_payload_json ||= JSON.generate(canonicalize_value(semantic_idempotency_payload))
+  end
+
+  def reference_attributes(batch)
+    {
+      TransactionReference::REFERENCE_TYPE_REFERENCE_NUMBER => @reference_number.presence,
+      TransactionReference::REFERENCE_TYPE_EXTERNAL_REFERENCE => @external_reference.presence,
+      TransactionReference::REFERENCE_TYPE_IDEMPOTENCY_KEY => batch.idempotency_key.presence
+    }.compact
   end
 
   def semantic_idempotency_payload

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -53,7 +53,7 @@
               <tr>
                 <td class="ui-mono"><%= txn.business_date&.strftime("%Y-%m-%d") %></td>
                 <td><%= txn.transaction_type %></td>
-                <td class="ui-mono"><%= txn.reference_number.presence || "—" %></td>
+                <td class="ui-mono"><%= txn.transaction_references.find { |reference| reference.reference_type == TransactionReference::REFERENCE_TYPE_REFERENCE_NUMBER }&.reference_value || txn.reference_number.presence || "—" %></td>
                 <td><span class="<%= status_pill_class(txn.status) %>"><%= txn.status %></span></td>
                 <td><%= txn.branch&.branch_code %></td>
                 <td><%= link_to "View", transaction_path(txn), class: "link link-primary text-sm" %></td>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -83,6 +83,37 @@
     </div>
   </section>
 
+  <section class="ui-panel mb-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Structured References</h2>
+        <p class="mt-1 text-sm text-base-content/65">Alternate lookup keys and external traceability values captured for this operational transaction.</p>
+      </div>
+    </div>
+    <div class="ui-panel-body">
+      <% if @transaction_references.any? %>
+        <table class="ui-ledger-table">
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @transaction_references.each do |reference| %>
+              <tr>
+                <td><%= reference.reference_type %></td>
+                <td class="ui-mono"><%= reference.reference_value %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-sm text-base-content/60">No structured references captured.</p>
+      <% end %>
+    </div>
+  </section>
+
   <% if reversible && batch_total_cents >= Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS %>
     <section class="ui-override-box mb-6">
       <div class="space-y-2">

--- a/db/migrate/20260309080000_create_transaction_references.rb
+++ b/db/migrate/20260309080000_create_transaction_references.rb
@@ -1,0 +1,50 @@
+class CreateTransactionReferences < ActiveRecord::Migration[8.1]
+  def up
+    create_table :transaction_references do |t|
+      t.references :transaction, null: false, foreign_key: true
+      t.string :reference_type, null: false
+      t.string :reference_value, null: false
+
+      t.timestamps
+    end
+
+    add_index :transaction_references, [ :transaction_id, :reference_type, :reference_value ],
+      unique: true,
+      name: "index_transaction_references_on_txn_type_value"
+    add_index :transaction_references, [ :reference_type, :reference_value ],
+      name: "index_transaction_references_on_type_and_value"
+
+    backfill_transaction_references!
+  end
+
+  def down
+    drop_table :transaction_references
+  end
+
+  private
+
+  def backfill_transaction_references!
+    execute <<~SQL
+      INSERT INTO transaction_references (transaction_id, reference_type, reference_value, created_at, updated_at)
+      SELECT id, 'reference_number', reference_number, NOW(), NOW()
+      FROM transactions
+      WHERE reference_number IS NOT NULL AND reference_number <> ''
+    SQL
+
+    execute <<~SQL
+      INSERT INTO transaction_references (transaction_id, reference_type, reference_value, created_at, updated_at)
+      SELECT id, 'external_reference', external_reference, NOW(), NOW()
+      FROM transactions
+      WHERE external_reference IS NOT NULL AND external_reference <> ''
+    SQL
+
+    execute <<~SQL
+      INSERT INTO transaction_references (transaction_id, reference_type, reference_value, created_at, updated_at)
+      SELECT posting_batches.operational_transaction_id, 'idempotency_key', posting_batches.idempotency_key, NOW(), NOW()
+      FROM posting_batches
+      WHERE posting_batches.operational_transaction_id IS NOT NULL
+        AND posting_batches.idempotency_key IS NOT NULL
+        AND posting_batches.idempotency_key <> ''
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_070000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_080000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -398,6 +398,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_070000) do
     t.index ["code"], name: "index_transaction_codes_on_code", unique: true
   end
 
+  create_table "transaction_references", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "reference_type", null: false
+    t.string "reference_value", null: false
+    t.bigint "transaction_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reference_type", "reference_value"], name: "index_transaction_references_on_type_and_value"
+    t.index ["transaction_id", "reference_type", "reference_value"], name: "index_transaction_references_on_txn_type_value", unique: true
+    t.index ["transaction_id"], name: "index_transaction_references_on_transaction_id"
+  end
+
   create_table "transactions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "approved_by_id"
     t.bigint "branch_id", null: false
@@ -486,6 +497,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_070000) do
   add_foreign_key "posting_template_legs", "posting_templates"
   add_foreign_key "posting_templates", "transaction_codes"
   add_foreign_key "role_permissions", "roles"
+  add_foreign_key "transaction_references", "transactions"
   add_foreign_key "transactions", "branches"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "users"

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -22,17 +22,19 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
   test "create posts ADJ_CREDIT and redirects" do
     account = accounts(:one)
     assert_difference "BankingTransaction.count", 1 do
-      post transactions_url, params: {
-        transaction: {
-          transaction_code: "ADJ_CREDIT",
-          account_id: account.id,
-          amount: "100.50",
-          memo: "Courtesy credit",
-          reason_text: "Service recovery",
-          reference_number: "MAN-20260309-001",
-          external_reference: "CASE-42"
+      assert_difference "TransactionReference.count", 2 do
+        post transactions_url, params: {
+          transaction: {
+            transaction_code: "ADJ_CREDIT",
+            account_id: account.id,
+            amount: "100.50",
+            memo: "Courtesy credit",
+            reason_text: "Service recovery",
+            reference_number: "MAN-20260309-001",
+            external_reference: "CASE-42"
+          }
         }
-      }
+      end
     end
     assert_redirected_to transaction_path(BankingTransaction.last)
     transaction = BankingTransaction.last
@@ -40,6 +42,7 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Service recovery", transaction.reason_text
     assert_equal "MAN-20260309-001", transaction.reference_number
     assert_equal "CASE-42", transaction.external_reference
+    assert_equal [ "external_reference", "reference_number" ], transaction.transaction_references.order(:reference_type).pluck(:reference_type)
     follow_redirect!
     assert_match /posted successfully/i, flash[:notice]
   end
@@ -74,6 +77,15 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     )
     get transaction_url(txn)
     assert_response :success
+  end
+
+  test "show renders structured references" do
+    get transaction_url(BankingTransaction.find_by!(reference_number: "TXN-002"))
+
+    assert_response :success
+    assert_select "h2", text: /Structured References/
+    assert_select "td", text: "reference_number"
+    assert_select "td", text: "TXN-002"
   end
 
   test "reverse requires reverse_transactions permission" do

--- a/test/fixtures/transaction_references.yml
+++ b/test/fixtures/transaction_references.yml
@@ -1,0 +1,14 @@
+<% ts = Time.zone.parse("2026-03-07 12:00:00") %>
+txn_one_reference_number:
+  operational_transaction: one
+  reference_type: reference_number
+  reference_value: TXN-001
+  created_at: <%= ts %>
+  updated_at: <%= ts %>
+
+txn_two_reference_number:
+  operational_transaction: two
+  reference_type: reference_number
+  reference_value: TXN-002
+  created_at: <%= ts %>
+  updated_at: <%= ts %>

--- a/test/services/posting_engine_test.rb
+++ b/test/services/posting_engine_test.rb
@@ -61,6 +61,8 @@ class PostingEngineTest < ActiveSupport::TestCase
     assert_equal transaction.id, account_transaction.transaction_id
     assert_includes account_transaction.description, "Courtesy credit"
     assert_includes account_transaction.description, "MAN-20260309-100"
+    assert_equal "MAN-20260309-100", transaction.transaction_references.find_by(reference_type: TransactionReference::REFERENCE_TYPE_REFERENCE_NUMBER)&.reference_value
+    assert_equal "CASE-100", transaction.transaction_references.find_by(reference_type: TransactionReference::REFERENCE_TYPE_EXTERNAL_REFERENCE)&.reference_value
   end
 
   test "records contra account context for internal transfers" do
@@ -135,6 +137,7 @@ class PostingEngineTest < ActiveSupport::TestCase
     )
 
     assert_equal batch1.id, batch2.id
+    assert_equal key, batch1.operational_transaction.transaction_references.find_by(reference_type: TransactionReference::REFERENCE_TYPE_IDEMPOTENCY_KEY)&.reference_value
   end
 
   test "idempotency rejects conflicting payload reuse" do


### PR DESCRIPTION
## Summary
- Add a dedicated `transaction_references` registry so operational transactions can carry structured alternate lookup keys instead of relying only on header columns.
- Persist `reference_number`, `external_reference`, and posting `idempotency_key` references automatically during posting and backfill them for existing rows.
- Extend transaction review coverage so operators can inspect structured references directly in the workstation.

## Test plan
- [x] `bin/rails db:migrate`
- [x] `bin/rails test test/services/posting_engine_test.rb test/controllers/transactions_controller_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

## Linked issue
- Closes #40

## Data / migration impact
- Adds the `transaction_references` table.
- Backfills reference-number, external-reference, and posting idempotency-key rows for existing data.

## Financial risk
- Low. This adds traceability records and does not change posting-leg balancing or account/GL mutation behavior.
- The posting path now writes reference rows in the same transaction as the operational transaction and posting batch.

## Rollback notes
- Revert this branch and roll back migration `20260309080000` if structured transaction references need to be removed.

Made with [Cursor](https://cursor.com)