### PR TITLE
Add explicit transaction exceptions

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -26,6 +26,7 @@ class TransactionsController < ApplicationController
 
   def show
     @posting_batch = @transaction.posting_batch
+    @transaction_exceptions = @transaction.transaction_exceptions.includes(:resolved_by).order(created_at: :desc)
     @transaction_references = @transaction.transaction_references.order(:reference_type, :id)
     @posting_legs = @posting_batch&.posting_legs&.includes(:account, :gl_account) || []
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
       "success"
     when "pending", "draft", "validated", "warning", "review_needed", "review", "override_required"
       "warning"
-    when "reversed", "denied", "closed", "inactive", "expired", "failed", "error", "rejected"
+    when "reversed", "denied", "closed", "inactive", "expired", "failed", "error", "rejected", "blocked"
       "error"
     else
       "neutral"

--- a/app/models/banking_transaction.rb
+++ b/app/models/banking_transaction.rb
@@ -8,6 +8,7 @@ class BankingTransaction < ApplicationRecord
   belongs_to :branch
   belongs_to :created_by, class_name: "User", optional: true
   has_many :account_transactions, foreign_key: :transaction_id, dependent: :nullify
+  has_many :transaction_exceptions, foreign_key: :transaction_id, dependent: :restrict_with_error
   has_many :transaction_references, foreign_key: :transaction_id, dependent: :restrict_with_error
   has_one :posting_batch, foreign_key: :operational_transaction_id
 

--- a/app/models/transaction_exception.rb
+++ b/app/models/transaction_exception.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class TransactionException < ApplicationRecord
+  EXCEPTION_TYPE_OVERRIDE_REQUIRED = "override_required"
+  EXCEPTION_TYPE_POLICY_BLOCKED = "policy_blocked"
+  EXCEPTION_TYPES = [
+    EXCEPTION_TYPE_OVERRIDE_REQUIRED,
+    EXCEPTION_TYPE_POLICY_BLOCKED
+  ].freeze
+
+  STATUS_OPEN = "open"
+  STATUS_RESOLVED = "resolved"
+  STATUS_BLOCKED = "blocked"
+  STATUSES = [
+    STATUS_OPEN,
+    STATUS_RESOLVED,
+    STATUS_BLOCKED
+  ].freeze
+
+  belongs_to :operational_transaction, class_name: "BankingTransaction", foreign_key: :transaction_id
+  belongs_to :resolved_by, class_name: "User", optional: true
+
+  validates :exception_type, presence: true, inclusion: { in: EXCEPTION_TYPES }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :reason_code, presence: true
+
+  scope :open, -> { where(status: STATUS_OPEN) }
+
+  def resolve!(resolved_by_id: nil)
+    update!(
+      status: STATUS_RESOLVED,
+      resolved_at: Time.current,
+      resolved_by_id: resolved_by_id
+    )
+  end
+
+  def block!(resolved_by_id: nil)
+    update!(
+      status: STATUS_BLOCKED,
+      resolved_at: Time.current,
+      resolved_by_id: resolved_by_id
+    )
+  end
+end

--- a/app/services/override_request_service.rb
+++ b/app/services/override_request_service.rb
@@ -53,6 +53,7 @@ class OverrideRequestService
       reason_text: @reason_text,
       expires_at: @expires_at
     )
+    ensure_transaction_exception_open!
 
     AuditEmissionService.emit!(
       event_type: AuditEmissionService::EVENT_OVERRIDE_REQUESTED,
@@ -75,6 +76,7 @@ class OverrideRequestService
       status: OVERRIDE_STATUS_APPROVED,
       approved_by_id: @approved_by_id
     )
+    resolve_transaction_exceptions!(resolved_by_id: @approved_by_id)
     emit_override_event!(AuditEmissionService::EVENT_OVERRIDE_APPROVED, "approve")
     @override_request
   end
@@ -86,6 +88,7 @@ class OverrideRequestService
       status: OVERRIDE_STATUS_DENIED,
       approved_by_id: @approved_by_id
     )
+    block_transaction_exceptions!(resolved_by_id: @approved_by_id)
     emit_override_event!(AuditEmissionService::EVENT_OVERRIDE_DENIED, "deny")
     @override_request
   end
@@ -96,11 +99,40 @@ class OverrideRequestService
     raise OverrideError, "Override has expired" if expired?(@override_request)
 
     @override_request.update!(status: OVERRIDE_STATUS_USED, used_at: Time.current)
+    resolve_transaction_exceptions!(resolved_by_id: @override_request.approved_by_id)
     emit_override_event!(AuditEmissionService::EVENT_OVERRIDE_USED, "use")
     @override_request
   end
 
   private
+
+  def ensure_transaction_exception_open!
+    return unless @operational_transaction_id.present?
+
+    TransactionException.find_or_create_by!(
+      transaction_id: @operational_transaction_id,
+      exception_type: exception_type_for_request(@request_type),
+      status: TransactionException::STATUS_OPEN,
+      reason_code: reason_code_for_request(@request_type),
+      requires_override: requires_override_for_request?(@request_type)
+    )
+  end
+
+  def resolve_transaction_exceptions!(resolved_by_id:)
+    return unless @override_request.operational_transaction_id.present?
+
+    matching_transaction_exceptions.find_each do |transaction_exception|
+      transaction_exception.resolve!(resolved_by_id: resolved_by_id)
+    end
+  end
+
+  def block_transaction_exceptions!(resolved_by_id:)
+    return unless @override_request.operational_transaction_id.present?
+
+    matching_transaction_exceptions.find_each do |transaction_exception|
+      transaction_exception.block!(resolved_by_id: resolved_by_id)
+    end
+  end
 
   def emit_override_event!(event_type, action)
     AuditEmissionService.emit!(
@@ -117,5 +149,30 @@ class OverrideRequestService
 
   def expired?(override_request)
     override_request.expires_at.present? && override_request.expires_at < Time.current
+  end
+
+  def matching_transaction_exceptions
+    TransactionException.open.where(
+      transaction_id: @override_request.operational_transaction_id,
+      exception_type: exception_type_for_request(@override_request.request_type)
+    )
+  end
+
+  def exception_type_for_request(request_type)
+    case request_type
+    when OVERRIDE_TYPE_REVERSAL then TransactionException::EXCEPTION_TYPE_OVERRIDE_REQUIRED
+    else TransactionException::EXCEPTION_TYPE_POLICY_BLOCKED
+    end
+  end
+
+  def reason_code_for_request(request_type)
+    case request_type
+    when OVERRIDE_TYPE_REVERSAL then "reversal_threshold"
+    else request_type
+    end
+  end
+
+  def requires_override_for_request?(request_type)
+    request_type == OVERRIDE_TYPE_REVERSAL
   end
 end

--- a/app/services/reversal_service.rb
+++ b/app/services/reversal_service.rb
@@ -19,6 +19,7 @@ class ReversalService
 
   def reverse!
     raise ReversalError, "Batch is not posted" unless @posting_batch.status == STATUS_POSTED
+    precheck_override_requirement!
 
     @posting_batch.with_lock do
       if @posting_batch.reversal_batch.present?
@@ -53,6 +54,18 @@ class ReversalService
   end
 
   private
+
+  def precheck_override_requirement!
+    return unless override_required?
+    return if @override_request.present?
+    return if OverrideRequest.usable.exists?(
+      operational_transaction_id: @posting_batch.operational_transaction_id,
+      request_type: OVERRIDE_TYPE_REVERSAL
+    )
+
+    create_override_required_exception!
+    raise OverrideRequiredError, override_required_message
+  end
 
   def create_reversal_batch!(reversal_code)
     legs = @posting_batch.posting_legs.order(:position)
@@ -118,6 +131,18 @@ class ReversalService
         reversal_code: reversal_code,
         idempotency_key: @idempotency_key
       }.compact
+    )
+  end
+
+  def create_override_required_exception!
+    return unless @posting_batch.operational_transaction_id.present?
+
+    TransactionException.find_or_create_by!(
+      transaction_id: @posting_batch.operational_transaction_id,
+      exception_type: TransactionException::EXCEPTION_TYPE_OVERRIDE_REQUIRED,
+      status: TransactionException::STATUS_OPEN,
+      reason_code: "reversal_threshold",
+      requires_override: true
     )
   end
 end

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -114,6 +114,45 @@
     </div>
   </section>
 
+  <section class="ui-panel mb-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Transaction Exceptions</h2>
+        <p class="mt-1 text-sm text-base-content/65">Explicit review-needed or policy-blocked states linked to this transaction.</p>
+      </div>
+    </div>
+    <div class="ui-panel-body">
+      <% if @transaction_exceptions.any? %>
+        <table class="ui-ledger-table">
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Reason</th>
+              <th>Override</th>
+              <th>Resolved</th>
+              <th>Resolved By</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @transaction_exceptions.each do |transaction_exception| %>
+              <tr>
+                <td><%= transaction_exception.exception_type %></td>
+                <td><span class="<%= status_pill_class(transaction_exception.status) %>"><%= transaction_exception.status %></span></td>
+                <td><%= transaction_exception.reason_code %></td>
+                <td><%= transaction_exception.requires_override ? "Required" : "Not Required" %></td>
+                <td class="ui-mono"><%= transaction_exception.resolved_at&.strftime("%Y-%m-%d %H:%M") || "—" %></td>
+                <td><%= transaction_exception.resolved_by&.display_name || transaction_exception.resolved_by&.username || "—" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="text-sm text-base-content/60">No transaction exceptions recorded.</p>
+      <% end %>
+    </div>
+  </section>
+
   <% if reversible && batch_total_cents >= Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS %>
     <section class="ui-override-box mb-6">
       <div class="space-y-2">

--- a/db/migrate/20260309090000_create_transaction_exceptions.rb
+++ b/db/migrate/20260309090000_create_transaction_exceptions.rb
@@ -1,0 +1,19 @@
+class CreateTransactionExceptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :transaction_exceptions do |t|
+      t.references :transaction, null: false, foreign_key: true
+      t.string :exception_type, null: false
+      t.string :status, null: false
+      t.boolean :requires_override, null: false, default: false
+      t.string :reason_code, null: false
+      t.datetime :resolved_at
+      t.references :resolved_by, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :transaction_exceptions, [ :transaction_id, :status ], name: "index_transaction_exceptions_on_txn_and_status"
+    add_index :transaction_exceptions, [ :transaction_id, :exception_type, :status ],
+      name: "index_transaction_exceptions_on_txn_type_and_status"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_080000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_090000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -398,6 +398,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_080000) do
     t.index ["code"], name: "index_transaction_codes_on_code", unique: true
   end
 
+  create_table "transaction_exceptions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "exception_type", null: false
+    t.string "reason_code", null: false
+    t.boolean "requires_override", default: false, null: false
+    t.datetime "resolved_at"
+    t.bigint "resolved_by_id"
+    t.string "status", null: false
+    t.bigint "transaction_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resolved_by_id"], name: "index_transaction_exceptions_on_resolved_by_id"
+    t.index ["transaction_id", "exception_type", "status"], name: "index_transaction_exceptions_on_txn_type_and_status"
+    t.index ["transaction_id", "status"], name: "index_transaction_exceptions_on_txn_and_status"
+    t.index ["transaction_id"], name: "index_transaction_exceptions_on_transaction_id"
+  end
+
   create_table "transaction_references", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "reference_type", null: false
@@ -497,6 +513,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_080000) do
   add_foreign_key "posting_template_legs", "posting_templates"
   add_foreign_key "posting_templates", "transaction_codes"
   add_foreign_key "role_permissions", "roles"
+  add_foreign_key "transaction_exceptions", "transactions"
+  add_foreign_key "transaction_exceptions", "users", column: "resolved_by_id"
   add_foreign_key "transaction_references", "transactions"
   add_foreign_key "transactions", "branches"
   add_foreign_key "user_roles", "roles"

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -88,6 +88,24 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "TXN-002"
   end
 
+  test "show renders transaction exceptions" do
+    transaction = BankingTransaction.find_by!(reference_number: "TXN-002")
+    TransactionException.create!(
+      operational_transaction: transaction,
+      exception_type: TransactionException::EXCEPTION_TYPE_OVERRIDE_REQUIRED,
+      status: TransactionException::STATUS_OPEN,
+      requires_override: true,
+      reason_code: "reversal_threshold"
+    )
+
+    get transaction_url(transaction)
+
+    assert_response :success
+    assert_select "h2", text: /Transaction Exceptions/
+    assert_select "td", text: "override_required"
+    assert_select "td", text: "reversal_threshold"
+  end
+
   test "reverse requires reverse_transactions permission" do
     batch = PostingEngine.post!(
       transaction_code: "ADJ_CREDIT",

--- a/test/services/override_request_service_test.rb
+++ b/test/services/override_request_service_test.rb
@@ -7,17 +7,26 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
     @branch = Branch.first || Branch.create!(branch_code: "T", name: "Test", status: "active")
     @user = User.create!(username: "req", display_name: "Requester", status: "active", password: "password", password_confirmation: "password")
     @approver = User.create!(username: "appr", display_name: "Approver", status: "active", password: "password", password_confirmation: "password")
+    @transaction = BankingTransaction.create!(
+      transaction_type: "ADJ_CREDIT",
+      branch: @branch,
+      status: Bankcore::Enums::STATUS_POSTED,
+      business_date: BusinessDateService.current
+    )
   end
 
   test "request! creates pending override" do
     req = nil
-    assert_difference "AuditEvent.count", 1 do
-      req = OverrideRequestService.request!(
-        request_type: "reversal",
-        requested_by_id: @user.id,
-        branch_id: @branch.id,
-        reason_text: "Correcting error"
-      )
+    assert_difference "TransactionException.count", 1 do
+      assert_difference "AuditEvent.count", 1 do
+        req = OverrideRequestService.request!(
+          request_type: "reversal",
+          requested_by_id: @user.id,
+          branch_id: @branch.id,
+          operational_transaction_id: @transaction.id,
+          reason_text: "Correcting error"
+        )
+      end
     end
 
     assert req.persisted?
@@ -25,13 +34,24 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
     assert_equal "reversal", req.request_type
     assert_equal @user.id, req.requested_by_id
     assert_equal "override_requested", AuditEvent.last.event_type
+    transaction_exception = TransactionException.last
+    assert_equal @transaction.id, transaction_exception.transaction_id
+    assert_equal TransactionException::STATUS_OPEN, transaction_exception.status
   end
 
   test "approve! updates status" do
+    TransactionException.create!(
+      operational_transaction: @transaction,
+      exception_type: TransactionException::EXCEPTION_TYPE_OVERRIDE_REQUIRED,
+      status: TransactionException::STATUS_OPEN,
+      requires_override: true,
+      reason_code: "reversal_threshold"
+    )
     req = OverrideRequestService.request!(
       request_type: "reversal",
       requested_by_id: @user.id,
-      branch_id: @branch.id
+      branch_id: @branch.id,
+      operational_transaction_id: @transaction.id
     )
 
     assert_difference "AuditEvent.count", 1 do
@@ -42,13 +62,24 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
     assert_equal "approved", req.status
     assert_equal @approver.id, req.approved_by_id
     assert_equal "override_approved", AuditEvent.last.event_type
+    transaction_exception = TransactionException.find_by!(transaction_id: @transaction.id, reason_code: "reversal_threshold")
+    assert_equal TransactionException::STATUS_RESOLVED, transaction_exception.status
+    assert_equal @approver.id, transaction_exception.resolved_by_id
   end
 
   test "deny! updates status" do
+    TransactionException.create!(
+      operational_transaction: @transaction,
+      exception_type: TransactionException::EXCEPTION_TYPE_OVERRIDE_REQUIRED,
+      status: TransactionException::STATUS_OPEN,
+      requires_override: true,
+      reason_code: "reversal_threshold"
+    )
     req = OverrideRequestService.request!(
       request_type: "reversal",
       requested_by_id: @user.id,
-      branch_id: @branch.id
+      branch_id: @branch.id,
+      operational_transaction_id: @transaction.id
     )
 
     assert_difference "AuditEvent.count", 1 do
@@ -58,13 +89,17 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
     req.reload
     assert_equal "denied", req.status
     assert_equal "override_denied", AuditEvent.last.event_type
+    transaction_exception = TransactionException.find_by!(transaction_id: @transaction.id, reason_code: "reversal_threshold")
+    assert_equal TransactionException::STATUS_BLOCKED, transaction_exception.status
+    assert_equal @approver.id, transaction_exception.resolved_by_id
   end
 
   test "use! marks override as used" do
     req = OverrideRequestService.request!(
       request_type: "reversal",
       requested_by_id: @user.id,
-      branch_id: @branch.id
+      branch_id: @branch.id,
+      operational_transaction_id: @transaction.id
     )
     OverrideRequestService.approve!(override_request: req, approved_by_id: @approver.id)
 
@@ -82,7 +117,8 @@ class OverrideRequestServiceTest < ActiveSupport::TestCase
     req = OverrideRequestService.request!(
       request_type: "reversal",
       requested_by_id: @user.id,
-      branch_id: @branch.id
+      branch_id: @branch.id,
+      operational_transaction_id: @transaction.id
     )
     OverrideRequestService.approve!(override_request: req, approved_by_id: @approver.id)
 

--- a/test/services/reversal_service_test.rb
+++ b/test/services/reversal_service_test.rb
@@ -78,11 +78,21 @@ class ReversalServiceTest < ActiveSupport::TestCase
   end
 
   test "raises when high-value reversal lacks override approval" do
-    error = assert_raises(ReversalService::OverrideRequiredError) do
-      ReversalService.reverse!(posting_batch: high_value_batch())
+    high_value_batch = high_value_batch()
+
+    error = nil
+    assert_difference "TransactionException.count", 1 do
+      error = assert_raises(ReversalService::OverrideRequiredError) do
+        ReversalService.reverse!(posting_batch: high_value_batch)
+      end
     end
 
     assert_match(/require supervisor approval/i, error.message)
+    transaction_exception = TransactionException.order(:id).last
+    assert_equal high_value_batch.operational_transaction_id, transaction_exception.transaction_id
+    assert_equal TransactionException::EXCEPTION_TYPE_OVERRIDE_REQUIRED, transaction_exception.exception_type
+    assert_equal TransactionException::STATUS_OPEN, transaction_exception.status
+    assert transaction_exception.requires_override
   end
 
   test "below-threshold reversal does not require override" do


### PR DESCRIPTION
## Summary
- Add a dedicated `transaction_exceptions` registry so override-required and policy-blocked workflow states are recorded directly on operational transactions.
- Create and transition exception records through governed reversal and override-request flows instead of relying only on controller redirects and audit events.
- Surface transaction exceptions on the transaction review screen so operators can see open, resolved, and blocked exception history in one place.

## Test plan
- [x] `bin/rails db:migrate`
- [x] `bin/rails test test/services/override_request_service_test.rb test/services/reversal_service_test.rb test/controllers/transactions_controller_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

## Linked issue
- Closes #42

## Data / migration impact
- Adds the `transaction_exceptions` table.
- No financial history backfill; new exception records are created as governed workflows run.

## Financial risk
- Low to moderate. This changes operator workflow state capture around governed reversals and override handling, but does not change posting-leg balancing or directly mutate financial history.
- Reversal prechecks now persist an exception record before raising when supervisor approval is required.

## Rollback notes
- Revert this branch and roll back migration `20260309090000` if explicit transaction exceptions need to be removed.

Made with [Cursor](https://cursor.com)