### PR TITLE
Add fee types admin UI

### DIFF
--- a/app/controllers/fee_types_controller.rb
+++ b/app/controllers/fee_types_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class FeeTypesController < ApplicationController
+  before_action :set_fee_type, only: %i[edit update]
+  before_action :set_form_options, only: %i[new create edit update]
+
+  def index
+    @fee_types = FeeType.includes(:gl_account, :fee_rules).order(:name)
+  end
+
+  def new
+    @fee_type = FeeType.new(status: Bankcore::Enums::STATUS_ACTIVE)
+  end
+
+  def create
+    @fee_type = FeeType.new(fee_type_params)
+    if @fee_type.save
+      redirect_to fee_types_path, notice: "Fee type created successfully."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @fee_type.update(fee_type_params)
+      redirect_to fee_types_path, notice: "Fee type updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_fee_type
+    @fee_type = FeeType.find(params[:id])
+  end
+
+  def set_form_options
+    @gl_accounts = GlAccount.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:gl_number)
+  end
+
+  def fee_type_params
+    params.require(:fee_type).permit(:code, :name, :default_amount_cents, :gl_account_id, :status)
+  end
+end

--- a/app/views/fee_types/_form.html.erb
+++ b/app/views/fee_types/_form.html.erb
@@ -1,0 +1,53 @@
+<%= form_with model: @fee_type, local: true, class: "space-y-4" do |f| %>
+  <% if @fee_type.errors.any? %>
+    <div class="alert alert-error mb-4">
+      <ul class="list-disc list-inside">
+        <% @fee_type.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="grid gap-4 lg:grid-cols-2">
+    <div class="form-control w-full">
+      <label class="label" for="fee_type_code">
+        <span class="label-text">Code</span>
+      </label>
+      <%= f.text_field :code, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_type_name">
+        <span class="label-text">Name</span>
+      </label>
+      <%= f.text_field :name, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_type_default_amount_cents">
+        <span class="label-text">Default Amount (cents)</span>
+      </label>
+      <%= f.number_field :default_amount_cents, class: "input input-bordered w-full ui-mono", min: 0, required: true %>
+    </div>
+
+    <div class="form-control w-full">
+      <label class="label" for="fee_type_status">
+        <span class="label-text">Status</span>
+      </label>
+      <%= f.select :status, Bankcore::Enums::STATUSES.map { |value| [value.titleize, value] }, {}, class: "select select-bordered w-full", required: true %>
+    </div>
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="fee_type_gl_account_id">
+      <span class="label-text">Income GL</span>
+    </label>
+    <%= f.collection_select :gl_account_id, @gl_accounts, :id, :name, { include_blank: "— None —" }, class: "select select-bordered w-full" %>
+  </div>
+
+  <div class="flex gap-2 pt-4">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", fee_types_path, class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/fee_types/edit.html.erb
+++ b/app/views/fee_types/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Edit #{@fee_type.name} - BankCORE" %>
+
+<div class="w-full max-w-4xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Fee Types", fee_types_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Edit Fee Type</h1>
+      <p class="workspace-subtitle">Update fee master data without altering historical fee assessments or posted transactions.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/fee_types/index.html.erb
+++ b/app/views/fee_types/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :title, "Fee Types - BankCORE" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back", root_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Fee Types</h1>
+      <p class="workspace-subtitle">Manage fee master data used by fee rules, assessments, and downstream income routing.</p>
+    </div>
+    <%= link_to "New Fee Type", new_fee_type_path, class: "btn btn-primary" %>
+  </div>
+
+  <div class="grid gap-4 lg:grid-cols-3 mb-6">
+    <div class="ui-metric">
+      <div class="ui-metric-label">Fee Types</div>
+      <div class="ui-metric-value ui-mono"><%= @fee_types.size %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Active</div>
+      <div class="ui-metric-value ui-mono"><%= @fee_types.count { |fee_type| fee_type.status == Bankcore::Enums::STATUS_ACTIVE } %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Linked Rules</div>
+      <div class="ui-metric-value ui-mono"><%= @fee_types.sum { |fee_type| fee_type.fee_rules.size } %></div>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Fee Type Catalog</h2>
+        <p class="mt-1 text-sm text-base-content/65">Master fee definitions used as the baseline for product-specific fee rules.</p>
+      </div>
+    </div>
+    <div class="ui-panel-body">
+      <table class="ui-ledger-table">
+        <thead>
+          <tr>
+            <th>Code</th>
+            <th>Name</th>
+            <th class="text-right">Default Amount</th>
+            <th>Income GL</th>
+            <th>Rules</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @fee_types.each do |fee_type| %>
+            <tr>
+              <td class="ui-mono"><%= fee_type.code %></td>
+              <td><%= fee_type.name %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(fee_type.default_amount_cents / 100.0) %></td>
+              <td class="ui-mono"><%= fee_type.gl_account&.gl_number || "—" %></td>
+              <td class="ui-mono"><%= fee_type.fee_rules.size %></td>
+              <td><span class="<%= status_pill_class(fee_type.status) %>"><%= fee_type.status %></span></td>
+              <td><%= link_to "Edit", edit_fee_type_path(fee_type), class: "btn btn-ghost btn-sm" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/app/views/fee_types/new.html.erb
+++ b/app/views/fee_types/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "New Fee Type - BankCORE" %>
+
+<div class="w-full max-w-4xl">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Fee Types", fee_types_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">New Fee Type</h1>
+      <p class="workspace-subtitle">Create a fee definition that can be reused across fee rules and fee assessment flows.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-body">
+      <%= render "form" %>
+    </div>
+  </section>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,6 +71,9 @@
               <%= link_to account_products_path, class: app_nav_link_class(account_products_path) do %>
                 <span>Account Products</span>
               <% end %>
+              <%= link_to fee_types_path, class: app_nav_link_class(fee_types_path) do %>
+                <span>Fee Types</span>
+              <% end %>
               <%= link_to gl_accounts_path, class: app_nav_link_class(gl_accounts_path) do %>
                 <span>GL Accounts</span>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
   resources :parties, only: %i[index show new create edit update]
 
+  resources :fee_types, only: %i[index new create edit update], path: "fee-types"
   resources :fee_assessments, only: %i[index], path: "fee-assessments"
   resources :interest_accruals, only: %i[index], path: "interest-accruals"
   resources :audit_events, only: %i[index], path: "audit-events"

--- a/test/controllers/fee_types_controller_test.rb
+++ b/test/controllers/fee_types_controller_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FeeTypesControllerTest < ActionDispatch::IntegrationTest
+  test "index renders fee types catalog" do
+    get fee_types_url
+
+    assert_response :success
+    assert_select "h1", text: /Fee Types/
+    assert_select "a", text: "New Fee Type"
+    assert_select "td", text: fee_types(:maintenance).code
+  end
+
+  test "new renders fee type form" do
+    get new_fee_type_url
+
+    assert_response :success
+    assert_select "form"
+    assert_select "input[name='fee_type[code]']"
+    assert_select "input[name='fee_type[name]']"
+    assert_select "input[name='fee_type[default_amount_cents]']"
+    assert_select "select[name='fee_type[gl_account_id]']"
+    assert_select "select[name='fee_type[status]']"
+  end
+
+  test "create creates fee type and redirects" do
+    assert_difference "FeeType.count", 1 do
+      post fee_types_url, params: {
+        fee_type: {
+          code: "WIRE_OUT",
+          name: "Outgoing Wire Fee",
+          default_amount_cents: 2_500,
+          gl_account_id: gl_accounts(:ten).id,
+          status: Bankcore::Enums::STATUS_ACTIVE
+        }
+      }
+    end
+
+    assert_redirected_to fee_types_path
+    fee_type = FeeType.order(:id).last
+    assert_equal "WIRE_OUT", fee_type.code
+    assert_equal gl_accounts(:ten).id, fee_type.gl_account_id
+  end
+
+  test "edit renders existing fee type" do
+    get edit_fee_type_url(fee_types(:maintenance))
+
+    assert_response :success
+    assert_select "h1", text: /Edit Fee Type/
+    assert_select "input[name='fee_type[code]'][value=?]", fee_types(:maintenance).code
+    assert_select "input[name='fee_type[name]'][value=?]", fee_types(:maintenance).name
+  end
+
+  test "update modifies fee type and redirects" do
+    patch fee_type_url(fee_types(:service_charge)), params: {
+      fee_type: {
+        code: "SERVICE_CHARGE",
+        name: "Updated Service Charge",
+        default_amount_cents: 900,
+        gl_account_id: gl_accounts(:eleven).id,
+        status: Bankcore::Enums::STATUS_INACTIVE
+      }
+    }
+
+    assert_redirected_to fee_types_path
+    fee_type = fee_types(:service_charge).reload
+    assert_equal "Updated Service Charge", fee_type.name
+    assert_equal 900, fee_type.default_amount_cents
+    assert_equal gl_accounts(:eleven).id, fee_type.gl_account_id
+    assert_equal Bankcore::Enums::STATUS_INACTIVE, fee_type.status
+  end
+end


### PR DESCRIPTION
Closes #44

## Summary
- add workstation CRUD screens for `FeeType` so fee master data can be maintained in-app instead of through seeds only
- add sidebar navigation and active GL selection so operators can reach and manage fee definitions from the back office UI
- add controller coverage for the new fee type admin flows

## Test plan
- [x] `bin/rails test test/controllers/fee_types_controller_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

Schema impact: none.
Financial risk: low; this adds admin UI for existing `FeeType` records and does not change posting logic.
UI notes: adds new Fee Types index/new/edit screens and sidebar navigation entry.
Rollback notes: revert this branch to remove the new fee type admin screens and navigation.

Made with [Cursor](https://cursor.com)