### PR TITLE
Add account references to accounts

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -51,7 +51,7 @@ class AccountsController < ApplicationController
   end
 
   def account_params
-    params.require(:account).permit(:account_number, :account_product_id, :branch_id)
+    params.require(:account).permit(:account_number, :account_reference, :account_product_id, :branch_id)
   end
 
   def create_deposit_account_if_needed!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -5,6 +5,8 @@ class Account < ApplicationRecord
 
   attr_accessor :primary_party_id
 
+  before_validation :default_account_reference
+
   belongs_to :branch
   belongs_to :account_product, optional: true
   has_many :account_owners
@@ -18,6 +20,7 @@ class Account < ApplicationRecord
   has_many :interest_accruals
 
   validates :account_number, presence: true, uniqueness: true
+  validates :account_reference, presence: true, uniqueness: true
   validates :account_type, presence: true, inclusion: { in: Bankcore::ACCOUNT_TYPES }
   validates :branch_id, presence: true
   validates :currency_code, presence: true
@@ -25,5 +28,11 @@ class Account < ApplicationRecord
 
   def product_code
     account_product&.product_code || account_type
+  end
+
+  private
+
+  def default_account_reference
+    self.account_reference = account_number if account_reference.blank?
   end
 end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -17,6 +17,13 @@
   </div>
 
   <div class="form-control w-full">
+    <label class="label" for="account_account_reference">
+      <span class="label-text">Account Reference</span>
+    </label>
+    <%= f.text_field :account_reference, class: "input input-bordered w-full font-mono", placeholder: "Defaults to the account number if left blank" %>
+  </div>
+
+  <div class="form-control w-full">
     <label class="label" for="account_account_product_id">
       <span class="label-text">Account Product</span>
     </label>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -50,7 +50,10 @@
           <% @accounts.each do |account| %>
             <% balance = account.account_balances.first %>
             <tr>
-              <td class="ui-mono"><%= account.account_number %></td>
+              <td>
+                <div class="ui-mono"><%= account.account_number %></div>
+                <div class="text-xs text-base-content/60"><%= account.account_reference %></div>
+              </td>
               <td><%= account.account_type %></td>
               <td><%= account.branch&.branch_code %></td>
               <td><span class="<%= status_pill_class(account.status) %>"><%= account.status %></span></td>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -41,6 +41,10 @@
 
         <div class="space-y-3 rounded-lg border border-base-300 bg-base-100 p-4">
           <div class="ui-kv-row">
+            <div class="ui-kv-label">Account Reference</div>
+            <div class="ui-kv-value ui-mono"><%= @account.account_reference %></div>
+          </div>
+          <div class="ui-kv-row">
             <div class="ui-kv-label">Branch</div>
             <div class="ui-kv-value"><%= @account.branch&.branch_code %></div>
           </div>

--- a/db/migrate/20260309093000_add_account_reference_to_accounts.rb
+++ b/db/migrate/20260309093000_add_account_reference_to_accounts.rb
@@ -1,0 +1,19 @@
+class AddAccountReferenceToAccounts < ActiveRecord::Migration[8.1]
+  def up
+    add_column :accounts, :account_reference, :string
+
+    execute <<~SQL.squish
+      UPDATE accounts
+      SET account_reference = account_number
+      WHERE account_reference IS NULL OR account_reference = ''
+    SQL
+
+    change_column_null :accounts, :account_reference, false
+    add_index :accounts, :account_reference, unique: true
+  end
+
+  def down
+    remove_index :accounts, :account_reference
+    remove_column :accounts, :account_reference
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_093000) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
@@ -90,6 +90,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_090000) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "account_number", null: false
     t.bigint "account_product_id"
+    t.string "account_reference", null: false
     t.string "account_type", null: false
     t.bigint "branch_id", null: false
     t.date "closed_on"
@@ -100,6 +101,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_090000) do
     t.datetime "updated_at", null: false
     t.index ["account_number"], name: "index_accounts_on_account_number", unique: true
     t.index ["account_product_id"], name: "index_accounts_on_account_product_id"
+    t.index ["account_reference"], name: "index_accounts_on_account_reference", unique: true
     t.index ["branch_id"], name: "index_accounts_on_branch_id"
   end
 

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -15,6 +15,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "form"
     assert_select "input[name='account[account_number]']"
+    assert_select "input[name='account[account_reference]']"
     assert_select "select[name='account[account_product_id]']"
     assert_select "select[name='account[branch_id]']"
     assert_select "input[name='account[currency_code]']", count: 0
@@ -27,6 +28,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       post accounts_url, params: {
         account: {
           account_number: "2001",
+          account_reference: "CHK-2001",
           account_product_id: product.id,
           branch_id: branch.id
         }
@@ -35,6 +37,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to account_path(Account.last)
     account = Account.last
     assert_equal "2001", account.account_number
+    assert_equal "CHK-2001", account.account_reference
     assert_equal product.id, account.account_product_id
     assert_equal "dda", account.account_type
     assert_equal "USD", account.currency_code
@@ -59,6 +62,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     end
 
     account = Account.last
+    assert_equal "2003", account.account_reference
     assert_equal "now", account.deposit_account.deposit_type
     assert_equal true, account.deposit_account.interest_bearing
     assert_equal "allow", account.deposit_account.overdraft_policy
@@ -72,6 +76,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       post accounts_url, params: {
         account: {
           account_number: "2002",
+          account_reference: "CHK-2002",
           account_product_id: product.id,
           branch_id: branch.id,
           primary_party_id: party.id
@@ -81,6 +86,15 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     account = Account.last
     assert_equal 1, account.account_owners.count
     assert_equal party.id, account.account_owners.first.party_id
+  end
+
+  test "show renders account reference" do
+    get account_url(accounts(:one))
+
+    assert_response :success
+    assert_select "h2", text: /Account/
+    assert_select ".ui-kv-label", text: "Account Reference"
+    assert_select ".ui-kv-value", text: /DDA-1001/
   end
 
   test "create with duplicate account number re-renders form" do

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,6 +1,7 @@
 <% ts = Time.zone.parse("2026-03-07 12:00:00") %>
 one:
   account_number: "1001"
+  account_reference: "DDA-1001"
   account_type: dda
   account_product: dda
   branch: one
@@ -12,6 +13,7 @@ one:
 
 two:
   account_number: "3001"
+  account_reference: "SAV-3001"
   account_type: savings
   account_product: savings
   branch: one


### PR DESCRIPTION
Closes #46

## Summary
- add `accounts.account_reference` with a backfill from existing account numbers so accounts carry a dedicated operational reference field
- expose account references in account create and review flows while defaulting blank references to the account number
- add test coverage for the new field in account controller flows

## Test plan
- [x] `bin/rails test test/controllers/accounts_controller_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

Schema impact: adds `accounts.account_reference` with a unique index and backfills existing rows from `account_number`.
Financial risk: low; this adds an alternate identifier on accounts and does not change posting, balance, or ledger behavior.
UI notes: account reference now appears on the new account form, account register, and account review screen.
Rollback notes: revert this branch to remove the column, migration, and UI wiring.

Made with [Cursor](https://cursor.com)