### PR TITLE
Add average balance tracking to account balances

### DIFF
--- a/app/models/account_balance.rb
+++ b/app/models/account_balance.rb
@@ -6,4 +6,5 @@ class AccountBalance < ApplicationRecord
   validates :account_id, presence: true
   validates :posted_balance_cents, presence: true, numericality: { only_integer: true }
   validates :available_balance_cents, presence: true, numericality: { only_integer: true }
+  validates :average_balance_cents, presence: true, numericality: { only_integer: true }
 end

--- a/app/services/balance_refresh_service.rb
+++ b/app/services/balance_refresh_service.rb
@@ -16,7 +16,8 @@ class BalanceRefreshService
   def refresh!
     @account_ids.each do |account_id|
       balance = compute_balance(account_id)
-      upsert_balance(account_id, balance)
+      average_balance = compute_average_balance(account_id)
+      upsert_balance(account_id, balance, average_balance)
     end
   end
 
@@ -39,7 +40,22 @@ class BalanceRefreshService
     ).sum(:amount_cents)
   end
 
-  def upsert_balance(account_id, balance_cents)
+  def compute_average_balance(account_id)
+    running_balance = 0
+    balance_points = AccountTransaction
+      .where(account_id: account_id)
+      .order(:posted_at, :id)
+      .pluck(:direction, :amount_cents)
+      .map do |direction, amount_cents|
+        running_balance += direction == "credit" ? amount_cents : -amount_cents
+      end
+
+    return 0 if balance_points.empty?
+
+    balance_points.sum / balance_points.size
+  end
+
+  def upsert_balance(account_id, balance_cents, average_balance_cents)
     holds_cents = active_holds_cents(account_id)
     available_cents = [ balance_cents - holds_cents, 0 ].max
 
@@ -47,6 +63,7 @@ class BalanceRefreshService
     balance.assign_attributes(
       posted_balance_cents: balance_cents,
       available_balance_cents: available_cents,
+      average_balance_cents: average_balance_cents,
       as_of_at: Time.current
     )
     balance.save!

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -34,6 +34,10 @@
             <div class="ui-kv-value ui-mono"><%= number_to_currency((@balance&.posted_balance_cents || 0) / 100.0) %></div>
           </div>
           <div class="ui-kv-row">
+            <div class="ui-kv-label">Average Balance</div>
+            <div class="ui-kv-value ui-mono"><%= number_to_currency((@balance&.average_balance_cents || 0) / 100.0) %></div>
+          </div>
+          <div class="ui-kv-row">
             <div class="ui-kv-label">Active Holds</div>
             <div class="ui-kv-value ui-mono"><%= number_to_currency(holds_total_cents / 100.0) %></div>
           </div>

--- a/db/migrate/20260309094500_add_average_balance_to_account_balances.rb
+++ b/db/migrate/20260309094500_add_average_balance_to_account_balances.rb
@@ -1,0 +1,15 @@
+class AddAverageBalanceToAccountBalances < ActiveRecord::Migration[8.1]
+  def up
+    add_column :account_balances, :average_balance_cents, :integer, default: 0, null: false
+
+    execute <<~SQL.squish
+      UPDATE account_balances
+      SET average_balance_cents = posted_balance_cents
+      WHERE average_balance_cents = 0
+    SQL
+  end
+
+  def down
+    remove_column :account_balances, :average_balance_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_093000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_094500) do
   create_table "account_balances", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "as_of_at"
     t.integer "available_balance_cents"
+    t.integer "average_balance_cents", default: 0, null: false
     t.datetime "created_at", null: false
     t.integer "posted_balance_cents"
     t.datetime "updated_at", null: false

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -89,12 +89,21 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show renders account reference" do
+    accounts(:one).account_balances.create!(
+      posted_balance_cents: 10_000,
+      available_balance_cents: 9_500,
+      average_balance_cents: 8_000,
+      as_of_at: Time.current
+    )
+
     get account_url(accounts(:one))
 
     assert_response :success
     assert_select "h2", text: /Account/
     assert_select ".ui-kv-label", text: "Account Reference"
     assert_select ".ui-kv-value", text: /DDA-1001/
+    assert_select ".ui-kv-label", text: "Average Balance"
+    assert_select ".ui-kv-value", text: /\$80\.00/
   end
 
   test "create with duplicate account number re-renders form" do

--- a/test/integration/posting_flow_test.rb
+++ b/test/integration/posting_flow_test.rb
@@ -31,6 +31,7 @@ class PostingFlowTest < ActiveSupport::TestCase
     balance = @account.account_balances.first
     assert balance, "Account balance should exist"
     assert_equal 4_000, balance.posted_balance_cents
+    assert_equal 4_000, balance.average_balance_cents
 
     # 4. Reverse
     reversal_batch = ReversalService.reverse!(posting_batch: batch)
@@ -42,6 +43,7 @@ class PostingFlowTest < ActiveSupport::TestCase
     @account.reload
     balance = @account.account_balances.first
     assert_equal 0, balance.posted_balance_cents
+    assert_equal 2_000, balance.average_balance_cents
   end
 
   test "ADJ_DEBIT posts and affects balance correctly" do
@@ -56,5 +58,6 @@ class PostingFlowTest < ActiveSupport::TestCase
     @account.reload
     balance = @account.account_balances.first
     assert_equal(-5000, balance.posted_balance_cents)
+    assert_equal(-5000, balance.average_balance_cents)
   end
 end

--- a/test/services/balance_refresh_service_test.rb
+++ b/test/services/balance_refresh_service_test.rb
@@ -22,6 +22,7 @@ class BalanceRefreshServiceTest < ActiveSupport::TestCase
     balance = @account.account_balances.first
     assert balance
     assert_equal 3000, balance.posted_balance_cents
+    assert_equal 3000, balance.average_balance_cents
   end
 
   test "rebuild! reconstructs balance from transactions" do
@@ -43,6 +44,7 @@ class BalanceRefreshServiceTest < ActiveSupport::TestCase
     @account.reload
     balance = @account.account_balances.first
     assert_equal 1500, balance.posted_balance_cents
+    assert_equal 1750, balance.average_balance_cents
   end
 
   test "available_balance subtracts active holds" do
@@ -65,5 +67,6 @@ class BalanceRefreshServiceTest < ActiveSupport::TestCase
     balance = @account.account_balances.first
     assert_equal 10_000, balance.posted_balance_cents
     assert_equal 7_000, balance.available_balance_cents
+    assert_equal 10_000, balance.average_balance_cents
   end
 end

--- a/test/services/interest_accrual_runner_service_test.rb
+++ b/test/services/interest_accrual_runner_service_test.rb
@@ -27,7 +27,11 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
   end
 
   test "skips account with zero balance" do
-    AccountBalance.find_by(account_id: @account.id).update!(posted_balance_cents: 0, available_balance_cents: 0)
+    AccountBalance.find_by(account_id: @account.id).update!(
+      posted_balance_cents: 0,
+      available_balance_cents: 0,
+      average_balance_cents: 0
+    )
 
     results = InterestAccrualRunnerService.run!(accrual_date: @accrual_date)
 
@@ -125,6 +129,7 @@ class InterestAccrualRunnerServiceTest < ActiveSupport::TestCase
     AccountBalance.find_or_create_by!(account_id: @account.id) do |b|
       b.posted_balance_cents = 100_000 # $1000
       b.available_balance_cents = 100_000
+      b.average_balance_cents = 100_000
       b.as_of_at = Time.current
     end
   end

--- a/test/services/interest_posting_runner_service_test.rb
+++ b/test/services/interest_posting_runner_service_test.rb
@@ -85,6 +85,7 @@ class InterestPostingRunnerServiceTest < ActiveSupport::TestCase
     balance = AccountBalance.find_or_initialize_by(account_id: @account.id)
     balance.posted_balance_cents ||= 0
     balance.available_balance_cents ||= 0
+    balance.average_balance_cents ||= 0
     balance.as_of_at ||= Time.current
     balance.save!
   end

--- a/test/services/posting_engine_test.rb
+++ b/test/services/posting_engine_test.rb
@@ -25,6 +25,7 @@ class PostingEngineTest < ActiveSupport::TestCase
     balance = @account.account_balances.first
     assert balance
     assert_equal 5000, balance.posted_balance_cents
+    assert_equal 5000, balance.average_balance_cents
   end
 
   test "creates journal entry and account transaction" do


### PR DESCRIPTION
Closes #48

## Summary
- add `account_balances.average_balance_cents` with a backfill so cached balance snapshots can carry an average-balance value
- compute and persist the average balance during balance refreshes and surface it on the account review screen
- extend balance and account tests to cover the new cached field and helper setup paths

## Test plan
- [x] `bin/rails test test/services/balance_refresh_service_test.rb test/controllers/accounts_controller_test.rb test/integration/posting_flow_test.rb`
- [x] `bin/rails test`
- [x] `bin/brakeman --no-pager`

Schema impact: adds `account_balances.average_balance_cents` with a default/backfill for existing rows.
Financial risk: low; this adds a derived cached field for reporting/review and does not change posting, balance integrity, or ledger entries.
UI notes: account review now shows Average Balance alongside posted and available balances.
Rollback notes: revert this branch to remove the cached field, migration, and UI display.

Made with [Cursor](https://cursor.com)