### PR TITLE
Add transaction rules and UI roadmap

### DIFF
--- a/docs/architecture/transaction_rules_ui_roadmap.md
+++ b/docs/architecture/transaction_rules_ui_roadmap.md
@@ -85,6 +85,24 @@ Add a transaction-entry namespace under `app/services/transaction_entry/`:
 - construct a canonical idempotency fingerprint per family
 - return a validated policy result that the dispatcher can consume
 
+### Shared Resources
+
+The request object and policy layer should explicitly support shared resources that may be reused across transaction families:
+
+- authorization references
+- override requests
+- original transaction or posting targets
+- fee rules
+- interest rules
+- external network references such as ACH trace and batch identifiers
+
+Recommended handling:
+
+- model them as first-class fields on the normalized request object, not hidden controller-only params
+- let each family policy declare whether the shared resource is required, optional, or forbidden
+- preserve them into transaction metadata and reference structures where they matter for auditability
+- avoid one monolithic "shared resource" table until the domain proves it is necessary; start with explicit request fields and traceable linkage
+
 ### Rules To Centralize First
 
 - active/postable account eligibility
@@ -208,6 +226,7 @@ Recommended controller directions:
 #### ACH
 
 - ACH trace number
+- authorization reference
 - originator or authorization reference
 - effective date
 - batch/file reference
@@ -218,6 +237,17 @@ Recommended controller directions:
 - preview of inverse posting impact
 - clear approval-threshold messaging before submit
 - direct linkage to override request status when approval is required
+
+### Shared Resources In The UI
+
+The shared transaction shell should support rendering shared-resource sections when a family requires them, for example:
+
+- an authorization section for ACH or other authorization-dependent families
+- an override section when policy review or supervisor approval is already in play
+- a rule-context section when fees or interest derive from `fee_rule_id` or `interest_rule_id`
+- an original-transaction section for reversals and correction-style workflows
+
+This keeps the UI consistent without flattening every family into the same field set.
 
 ## 4. Review And Navigation Surfaces
 

--- a/docs/progress/transaction_requirements_matrix.md
+++ b/docs/progress/transaction_requirements_matrix.md
@@ -69,6 +69,8 @@ Family-specific fields that the current generic form does not model consistently
 
 - `fee_type_id`
 - `fee_rule_id`
+- `authorization_reference`
+- `authorization_source`
 - `original_fee_assessment_id`
 - `interest_rule_id`
 - `accrual_date`
@@ -78,6 +80,27 @@ Family-specific fields that the current generic form does not model consistently
 - `ach_batch_reference`
 - `override_request_id`
 - `reversal_target_transaction_id`
+
+## Shared Resources And References
+
+Some fields should be treated as shared resources rather than incidental free-text metadata because they connect transaction families to other governed workflows or external control evidence.
+
+Cross-cutting shared resources to model explicitly:
+
+- `authorization_reference`
+  - used when a transaction depends on customer authorization, ACH authorization, or another governed approval artifact
+- `override_request_id`
+  - used when a transaction depends on a supervisor approval or governed exception path
+- `reversal_target_transaction_id`
+  - used when a new transaction is explicitly correcting or reversing an existing one
+- `fee_rule_id`
+  - used when fee posting is driven by a product/rule decision that should remain traceable
+- `interest_rule_id`
+  - used when accrual or posting is justified by a specific product rule
+- external network references such as `ach_trace_number`, `ach_batch_reference`, and `external_reference`
+  - used for settlement traceability and duplicate detection
+
+These resources should be captured in the normalized request object and validated by family policy objects, even when they are only required for a subset of transaction families.
 
 ## Implementation Notes
 


### PR DESCRIPTION
Closes #50

## Summary
- add a transaction requirements matrix that translates the existing transaction catalog docs into one implementation-facing contract for all current transaction families
- add an architecture roadmap for transaction policy validation, family-aware dispatch, transaction-family workstation UI, and phased rollout/testing
- anchor the roadmap to the current transaction controller, manual entry service, fee/interest services, reversal flow, and review surfaces

## Test plan
- [x] Documentation-only change; no code paths or schema changed

Schema impact: none.
Financial risk: none; this documents the next implementation phase without changing posting behavior.
UI notes: none; this roadmap describes future UI work but does not change current screens.
Rollback notes: revert this branch to remove the new roadmap docs.

Made with [Cursor](https://cursor.com)