### PR TITLE
Implement family-aware transaction entry

### DIFF
--- a/app/controllers/interest_accruals_controller.rb
+++ b/app/controllers/interest_accruals_controller.rb
@@ -1,12 +1,35 @@
 # frozen_string_literal: true
 
 class InterestAccrualsController < ApplicationController
+  before_action -> { require_permission(:post_transactions) }, only: %i[run]
+
   def index
+    load_workbench
     @interest_accruals = InterestAccrual
       .includes(:account)
       .order(accrual_date: :desc, created_at: :desc)
       .limit(100)
 
     @interest_accruals = @interest_accruals.where(account_id: params[:account_id]) if params[:account_id].present?
+  end
+
+  def run
+    load_workbench
+    @run_results = InterestAccrualRunnerService.run!(accrual_date: @business_date)
+    @interest_accruals = InterestAccrual
+      .includes(:account)
+      .order(accrual_date: :desc, created_at: :desc)
+      .limit(100)
+
+    render :index
+  rescue StandardError => e
+    redirect_to interest_accruals_path, alert: "Interest accrual run failed: #{e.message}"
+  end
+
+  private
+
+  def load_workbench
+    @business_date = BusinessDateService.current
+    @active_interest_rules = InterestRule.includes(:account_product).active_on(@business_date).ordered
   end
 end

--- a/app/controllers/interest_postings_controller.rb
+++ b/app/controllers/interest_postings_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class InterestPostingsController < ApplicationController
+  before_action -> { require_permission(:post_transactions) }, only: %i[create]
+
+  def index
+    load_workbench
+  end
+
+  def create
+    load_workbench
+    @run_results = InterestPostingRunnerService.run!(business_date: @business_date)
+    render :index
+  rescue StandardError => e
+    redirect_to interest_postings_path, alert: "Interest posting run failed: #{e.message}"
+  end
+
+  private
+
+  def load_workbench
+    @business_date = BusinessDateService.current
+    @due_accounts = due_accounts
+  end
+
+  def due_accounts
+    active_rules = InterestRule.active_on(@business_date).ordered.each_with_object({}) do |rule, result|
+      result[rule.account_product_id] ||= rule
+    end
+    return [] if active_rules.empty?
+
+    Account
+      .includes(:account_product, :deposit_account)
+      .joins(:deposit_account)
+      .where(status: Bankcore::Enums::STATUS_ACTIVE, account_product_id: active_rules.keys)
+      .where(deposit_accounts: { interest_bearing: true })
+      .map do |account|
+        accruals = InterestAccrual
+          .unposted
+          .where(account_id: account.id, status: Bankcore::Enums::STATUS_POSTED)
+          .where("accrual_date <= ?", @business_date)
+          .order(:accrual_date, :id)
+
+        next if accruals.empty?
+
+        {
+          account: account,
+          posting_cadence: active_rules[account.account_product_id]&.posting_cadence,
+          accrual_count: accruals.size,
+          amount_cents: accruals.sum(:amount_cents)
+        }
+      end.compact
+  end
+end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -7,15 +7,22 @@ class TransactionsController < ApplicationController
     source_account_id
     destination_account_id
     amount
+    fee_type_id
     memo
     reason_text
     reference_number
     external_reference
     idempotency_key
+    ach_trace_number
+    ach_effective_date
+    ach_batch_reference
+    authorization_reference
+    authorization_source
   ].freeze
 
-  before_action :set_transaction, only: %i[show reverse]
-  before_action -> { require_permission(:reverse_transactions) }, only: %i[reverse]
+  before_action :set_transaction, only: %i[show reverse reverse_preview]
+  before_action -> { require_permission(:post_transactions) }, only: %i[new create]
+  before_action -> { require_permission(:reverse_transactions) }, only: %i[reverse reverse_preview]
 
   def index
     @transactions = BankingTransaction
@@ -44,9 +51,7 @@ class TransactionsController < ApplicationController
   end
 
   def new
-    @transaction_codes = TransactionCode.where(active: true).order(:code)
-    @accounts = Account.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:account_number)
-    @business_date = BusinessDateService.current
+    load_form_dependencies
     @preselected_account_id = params[:account_id]
   end
 
@@ -56,26 +61,31 @@ class TransactionsController < ApplicationController
       return
     end
 
-    form_params = transaction_form_params
-    amount_cents = (form_params[:amount].to_f * 100).round
-    batch = ManualTransactionEntryService.entry!(
-      transaction_code: form_params[:transaction_code],
-      account_id: form_params[:account_id].presence,
-      source_account_id: form_params[:source_account_id].presence,
-      destination_account_id: form_params[:destination_account_id].presence,
-      amount_cents: amount_cents,
-      memo: form_params[:memo].presence,
-      reason_text: form_params[:reason_text].presence,
-      reference_number: form_params[:reference_number].presence,
-      external_reference: form_params[:external_reference].presence,
-      idempotency_key: form_params[:idempotency_key].presence,
-      created_by_id: current_user&.id
-    )
+    request = transaction_entry_request
+    batch = TransactionEntry::Dispatcher.post!(request: request)
     redirect_to transaction_path(batch.operational_transaction_id), notice: "Transaction posted successfully."
-  rescue PostingEngine::PostingError, PostingValidator::ValidationError => e
+  rescue PostingEngine::PostingError, PostingValidator::ValidationError, TransactionEntry::Error, ArgumentError => e
     load_form_dependencies
     flash.now[:alert] = e.message
     render :new, status: :unprocessable_entity
+  end
+
+  def reverse_preview
+    @posting_batch = @transaction.posting_batch
+    raise ActiveRecord::RecordNotFound, "No posting batch" unless @posting_batch
+
+    @preview_legs = @posting_batch.posting_legs.includes(:account, :gl_account).order(:position).map do |leg|
+      {
+        leg_type: leg.leg_type == Bankcore::Enums::LEG_TYPE_DEBIT ? Bankcore::Enums::LEG_TYPE_CREDIT : Bankcore::Enums::LEG_TYPE_DEBIT,
+        ledger_scope: leg.ledger_scope,
+        account: leg.account,
+        gl_account: leg.gl_account,
+        amount_cents: leg.amount_cents
+      }
+    end
+    @economic_amount_cents = @posting_batch.posting_legs.minimum(:amount_cents).to_i
+    @override_threshold_cents = Bankcore::REVERSAL_OVERRIDE_THRESHOLD_CENTS
+    @override_required = @economic_amount_cents >= @override_threshold_cents
   end
 
   private
@@ -85,37 +95,16 @@ class TransactionsController < ApplicationController
   end
 
   def preview_transaction
-    form_params = transaction_form_params
-    amount_cents = (form_params[:amount].to_f * 100).round
-    @preview_legs = PostingEngine.preview!(
-      transaction_code: form_params[:transaction_code],
-      account_id: form_params[:account_id].presence,
-      source_account_id: form_params[:source_account_id].presence,
-      destination_account_id: form_params[:destination_account_id].presence,
-      amount_cents: amount_cents,
-      memo: form_params[:memo].presence,
-      reason_text: form_params[:reason_text].presence,
-      reference_number: form_params[:reference_number].presence,
-      external_reference: form_params[:external_reference].presence,
-      gl_account_id: params[:gl_account_id].presence
-    )
-    @transaction_code = form_params[:transaction_code]
-    @amount_cents = amount_cents
-    @params_for_confirm = {
-      transaction_code: form_params[:transaction_code],
-      account_id: form_params[:account_id].presence,
-      source_account_id: form_params[:source_account_id].presence,
-      destination_account_id: form_params[:destination_account_id].presence,
-      amount: form_params[:amount],
-      memo: form_params[:memo].presence,
-      reason_text: form_params[:reason_text].presence,
-      reference_number: form_params[:reference_number].presence,
-      external_reference: form_params[:external_reference].presence,
-      idempotency_key: form_params[:idempotency_key].presence
-    }.compact
-    @preview_metadata = @params_for_confirm.slice(:memo, :reason_text, :reference_number, :external_reference, :idempotency_key)
+    request = transaction_entry_request
+    preview = TransactionEntry::PreviewService.preview!(request: request)
+    @preview_legs = preview[:legs]
+    @transaction_code = request.transaction_code
+    @amount_cents = preview[:amount_cents]
+    @params_for_confirm = request.to_form_params
+    @preview_metadata = preview[:metadata]
+    @preview_context_rows = preview[:context_rows]
     render :preview
-  rescue PostingEngine::PostingError, PostingValidator::ValidationError => e
+  rescue PostingEngine::PostingError, PostingValidator::ValidationError, TransactionEntry::Error, ArgumentError => e
     load_form_dependencies
     flash.now[:alert] = e.message
     render :new, status: :unprocessable_entity
@@ -131,8 +120,17 @@ class TransactionsController < ApplicationController
   end
 
   def load_form_dependencies
-    @transaction_codes = TransactionCode.where(active: true).order(:code)
-    @accounts = Account.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:account_number)
+    @transaction_codes = TransactionCode.where(active: true, code: TransactionEntry::Request::MANUAL_ENTRY_CODES).order(:code)
+    @accounts = Account.where(status: Bankcore::Enums::STATUS_ACTIVE).includes(:account_product).order(:account_number)
+    @fee_types = FeeType.where(status: Bankcore::Enums::STATUS_ACTIVE).order(:name)
     @business_date = BusinessDateService.current
+  end
+
+  def transaction_entry_request
+    TransactionEntry::Request.from_form(
+      raw_params: transaction_form_params,
+      created_by_id: current_user&.id,
+      business_date: BusinessDateService.current
+    )
   end
 end

--- a/app/models/transaction_reference.rb
+++ b/app/models/transaction_reference.rb
@@ -4,6 +4,11 @@ class TransactionReference < ApplicationRecord
   REFERENCE_TYPE_REFERENCE_NUMBER = "reference_number"
   REFERENCE_TYPE_EXTERNAL_REFERENCE = "external_reference"
   REFERENCE_TYPE_IDEMPOTENCY_KEY = "idempotency_key"
+  REFERENCE_TYPE_ACH_TRACE_NUMBER = "ach_trace_number"
+  REFERENCE_TYPE_ACH_EFFECTIVE_DATE = "ach_effective_date"
+  REFERENCE_TYPE_ACH_BATCH_REFERENCE = "ach_batch_reference"
+  REFERENCE_TYPE_AUTHORIZATION_REFERENCE = "authorization_reference"
+  REFERENCE_TYPE_AUTHORIZATION_SOURCE = "authorization_source"
 
   belongs_to :operational_transaction, class_name: "BankingTransaction", foreign_key: :transaction_id
 

--- a/app/services/ach_entry_service.rb
+++ b/app/services/ach_entry_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class AchEntryService
+  def self.post!(**params)
+    new(**params).post!
+  end
+
+  def initialize(transaction_code:, account_id:, amount_cents:, business_date: nil, memo: nil, reason_text: nil,
+                 reference_number: nil, external_reference: nil, idempotency_key: nil, created_by_id: nil,
+                 ach_trace_number:, ach_effective_date:, ach_batch_reference:, authorization_reference: nil,
+                 authorization_source: nil)
+    @transaction_code = transaction_code
+    @account_id = account_id
+    @amount_cents = amount_cents
+    @business_date = business_date || BusinessDateService.current
+    @memo = memo
+    @reason_text = reason_text
+    @reference_number = reference_number
+    @external_reference = external_reference
+    @idempotency_key = idempotency_key
+    @created_by_id = created_by_id
+    @ach_trace_number = ach_trace_number
+    @ach_effective_date = ach_effective_date
+    @ach_batch_reference = ach_batch_reference
+    @authorization_reference = authorization_reference
+    @authorization_source = authorization_source
+  end
+
+  def post!
+    ActiveRecord::Base.transaction do
+      posting_batch = PostingEngine.post!(
+        transaction_code: @transaction_code,
+        account_id: @account_id,
+        amount_cents: @amount_cents,
+        business_date: @business_date,
+        memo: @memo,
+        reason_text: @reason_text,
+        reference_number: @reference_number,
+        external_reference: @external_reference,
+        idempotency_key: @idempotency_key,
+        created_by_id: @created_by_id,
+        idempotency_context: ach_idempotency_context
+      )
+
+      persist_references!(posting_batch.operational_transaction)
+      posting_batch
+    end
+  end
+
+  private
+
+  def ach_idempotency_context
+    {
+      service: "ach_entry",
+      ach_trace_number: @ach_trace_number,
+      ach_effective_date: @ach_effective_date&.to_date&.iso8601,
+      ach_batch_reference: @ach_batch_reference,
+      authorization_reference: @authorization_reference,
+      authorization_source: @authorization_source
+    }.compact
+  end
+
+  def persist_references!(operational_transaction)
+    reference_attributes.each do |reference_type, reference_value|
+      TransactionReference.find_or_create_by!(
+        operational_transaction: operational_transaction,
+        reference_type: reference_type,
+        reference_value: reference_value
+      )
+    end
+  end
+
+  def reference_attributes
+    {
+      TransactionReference::REFERENCE_TYPE_ACH_TRACE_NUMBER => @ach_trace_number,
+      TransactionReference::REFERENCE_TYPE_ACH_EFFECTIVE_DATE => @ach_effective_date&.to_date&.iso8601,
+      TransactionReference::REFERENCE_TYPE_ACH_BATCH_REFERENCE => @ach_batch_reference,
+      TransactionReference::REFERENCE_TYPE_AUTHORIZATION_REFERENCE => @authorization_reference,
+      TransactionReference::REFERENCE_TYPE_AUTHORIZATION_SOURCE => @authorization_source
+    }.compact
+  end
+end

--- a/app/services/manual_transaction_entry_service.rb
+++ b/app/services/manual_transaction_entry_service.rb
@@ -7,7 +7,9 @@ class ManualTransactionEntryService
 
   def initialize(transaction_code:, account_id: nil, source_account_id: nil, destination_account_id: nil,
                  amount_cents:, memo: nil, reason_text: nil, reference_number: nil, external_reference: nil,
-                 idempotency_key: nil, created_by_id: nil, gl_account_id: nil)
+                 idempotency_key: nil, created_by_id: nil, gl_account_id: nil, fee_type_id: nil,
+                 ach_trace_number: nil, ach_effective_date: nil, ach_batch_reference: nil,
+                 authorization_reference: nil, authorization_source: nil, business_date: nil)
     @transaction_code = transaction_code
     @account_id = account_id
     @source_account_id = source_account_id
@@ -20,14 +22,22 @@ class ManualTransactionEntryService
     @idempotency_key = idempotency_key
     @created_by_id = created_by_id
     @gl_account_id = gl_account_id
+    @fee_type_id = fee_type_id
+    @ach_trace_number = ach_trace_number
+    @ach_effective_date = ach_effective_date
+    @ach_batch_reference = ach_batch_reference
+    @authorization_reference = authorization_reference
+    @authorization_source = authorization_source
+    @business_date = business_date || BusinessDateService.current
   end
 
   def entry!
-    PostingEngine.post!(
+    request = TransactionEntry::Request.new(
       transaction_code: @transaction_code,
       account_id: @account_id,
       source_account_id: @source_account_id,
       destination_account_id: @destination_account_id,
+      amount: format("%.2f", @amount_cents.to_i / 100.0),
       amount_cents: @amount_cents,
       memo: @memo,
       reason_text: @reason_text,
@@ -35,7 +45,16 @@ class ManualTransactionEntryService
       external_reference: @external_reference,
       idempotency_key: @idempotency_key,
       created_by_id: @created_by_id,
+      business_date: @business_date,
+      fee_type_id: @fee_type_id,
+      ach_trace_number: @ach_trace_number,
+      ach_effective_date: @ach_effective_date,
+      ach_batch_reference: @ach_batch_reference,
+      authorization_reference: @authorization_reference,
+      authorization_source: @authorization_source,
       gl_account_id: @gl_account_id
     )
+
+    TransactionEntry::Dispatcher.post!(request: request)
   end
 end

--- a/app/services/transaction_entry.rb
+++ b/app/services/transaction_entry.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  class Error < StandardError; end
+  class ValidationError < Error; end
+  class UnsupportedTransactionError < Error; end
+end

--- a/app/services/transaction_entry/dispatcher.rb
+++ b/app/services/transaction_entry/dispatcher.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  class Dispatcher
+    def self.preview!(request:)
+      new(request: request).preview!
+    end
+
+    def self.post!(request:)
+      new(request: request).post!
+    end
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def preview!
+      current_policy.validate!
+      ensure_manual_shell_support!
+
+      {
+        legs: PostingEngine.preview!(**current_policy.preview_attributes),
+        amount_cents: current_policy.resolved_amount_cents,
+        metadata: current_policy.preview_metadata,
+        context_rows: current_policy.preview_context_rows
+      }
+    end
+
+    def post!
+      current_policy.validate!
+
+      case @request.family
+      when :adjustment, :transfer
+        PostingEngine.post!(**current_policy.post_attributes)
+      when :fee
+        FeePostingService.assess!(**current_policy.fee_service_attributes)
+      when :ach
+        AchEntryService.post!(**current_policy.ach_service_attributes)
+      else
+        raise UnsupportedTransactionError, "#{@request.transaction_code} must use its dedicated workflow"
+      end
+    end
+
+    private
+
+    def current_policy
+      @current_policy ||= PolicyRegistry.build(@request)
+    end
+
+    def ensure_manual_shell_support!
+      return if @request.manual_entry_code?
+
+      raise UnsupportedTransactionError, "#{@request.transaction_code} must use its dedicated workflow"
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/ach_policy.rb
+++ b/app/services/transaction_entry/policies/ach_policy.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class AchPolicy < BasePolicy
+      def validate!
+        super
+        active_account!(request.account_id)
+        validate_positive_amount!
+        require_field!(:ach_trace_number, "ACH trace number is required")
+        require_field!(:ach_effective_date, "ACH effective date is required")
+        require_field!(:ach_batch_reference, "ACH batch reference is required")
+        require_field!(:authorization_reference, "Authorization reference is required for ACH debits") if request.transaction_code == "ACH_DEBIT"
+        self
+      end
+
+      def preview_context_rows
+        rows = [
+          [ "ACH Trace", request.ach_trace_number ],
+          [ "Effective Date", request.ach_effective_date&.iso8601 ],
+          [ "Batch Reference", request.ach_batch_reference ]
+        ]
+        rows << [ "Authorization", request.authorization_reference ] if request.authorization_reference.present?
+        rows
+      end
+
+      def ach_service_attributes
+        post_attributes.merge(
+          ach_trace_number: request.ach_trace_number,
+          ach_effective_date: request.ach_effective_date,
+          ach_batch_reference: request.ach_batch_reference,
+          authorization_reference: request.authorization_reference,
+          authorization_source: request.authorization_source
+        )
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/adjustment_policy.rb
+++ b/app/services/transaction_entry/policies/adjustment_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class AdjustmentPolicy < BasePolicy
+      def validate!
+        super
+        active_account!(request.account_id)
+        validate_positive_amount!
+        require_field!(:reason_text, "Reason / justification is required for manual adjustments")
+        require_field!(:reference_number, "Reference number is required for manual adjustments")
+        self
+      end
+
+      def preview_context_rows
+        [
+          [ "Mode", request.transaction_code == "ADJ_DEBIT" ? "Manual debit adjustment" : "Manual credit adjustment" ],
+          [ "Policy", request.transaction_code == "ADJ_DEBIT" ? "Debit adjustments require explicit reason and reference capture." : "Credit adjustments remain operator-governed and fully traceable." ]
+        ]
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/base_policy.rb
+++ b/app/services/transaction_entry/policies/base_policy.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class BasePolicy
+      attr_reader :request
+
+      def initialize(request)
+        @request = request
+      end
+
+      def validate!
+        require_transaction_code!
+        validate_business_date!
+        self
+      end
+
+      def resolved_amount_cents
+        request.amount_cents
+      end
+
+      def preview_context_rows
+        []
+      end
+
+      def preview_metadata
+        request.preview_metadata
+      end
+
+      def post_attributes
+        {
+          transaction_code: request.transaction_code,
+          account_id: request.account_id,
+          source_account_id: request.source_account_id,
+          destination_account_id: request.destination_account_id,
+          amount_cents: resolved_amount_cents,
+          business_date: request.business_date,
+          memo: request.memo,
+          reason_text: request.reason_text,
+          reference_number: request.reference_number,
+          external_reference: request.external_reference,
+          idempotency_key: request.idempotency_key,
+          created_by_id: request.created_by_id,
+          gl_account_id: request.gl_account_id
+        }.compact
+      end
+
+      def preview_attributes
+        post_attributes.except(:created_by_id, :idempotency_key)
+      end
+
+      protected
+
+      def require_transaction_code!
+        raise ValidationError, "Transaction code is required" if request.transaction_code.blank?
+      end
+
+      def validate_business_date!
+        return if BusinessDateService.open?(request.business_date)
+
+        raise ValidationError, "Business date #{request.business_date} is not open for posting"
+      end
+
+      def require_field!(field_name, message = nil)
+        return if request.public_send(field_name).present?
+
+        raise ValidationError, message || "#{field_name.to_s.humanize} is required"
+      end
+
+      def require_one_of!(*field_names)
+        return if field_names.any? { |field_name| request.public_send(field_name).present? }
+
+        joined_names = field_names.map { |field_name| field_name.to_s.humanize.downcase }.join(" or ")
+        raise ValidationError, "#{joined_names} is required"
+      end
+
+      def validate_positive_amount!
+        raise ValidationError, "Amount is required" if request.amount_cents.blank?
+        raise ValidationError, "Amount must be positive" if request.amount_cents <= 0
+      end
+
+      def active_account!(account_id)
+        account = Account.find_by(id: account_id)
+        raise ValidationError, "Account is required" if account.nil?
+        raise ValidationError, "Account #{account.account_number} is not active" unless account.status == Bankcore::Enums::STATUS_ACTIVE
+
+        account
+      end
+
+      def active_fee_type!
+        fee_type = FeeType.find_by(id: request.fee_type_id)
+        raise ValidationError, "Fee type is required" if fee_type.nil?
+        raise ValidationError, "Fee type #{fee_type.code} is not active" unless fee_type.status == Bankcore::Enums::STATUS_ACTIVE
+
+        fee_type
+      end
+
+      def active_interest_rule!(account)
+        interest_rule = InterestRule
+          .where(account_product_id: account.account_product_id)
+          .active_on(request.business_date)
+          .ordered
+          .first
+
+        raise ValidationError, "No active interest rule for the selected account product" unless interest_rule
+
+        interest_rule
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/fee_policy.rb
+++ b/app/services/transaction_entry/policies/fee_policy.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class FeePolicy < BasePolicy
+      def validate!
+        super
+        active_account!
+        active_fee_type!
+        validate_amount_override!
+        resolve_fee_rule!
+        self
+      end
+
+      def resolved_amount_cents
+        request.amount_cents || resolved_fee_rule.amount_cents_for_assessment
+      end
+
+      def preview_context_rows
+        [
+          [ "Fee Type", active_fee_type!.code ],
+          [ "Fee Rule", resolved_fee_rule.id.to_s ],
+          [ "Amount Source", request.amount_cents.present? ? "Manual override" : "Fee rule / fee type default" ]
+        ]
+      end
+
+      def preview_attributes
+        super.merge(gl_account_id: resolved_gl_account_id)
+      end
+
+      def fee_service_attributes
+        {
+          account_id: active_account!.id,
+          fee_type_id: active_fee_type!.id,
+          fee_rule_id: resolved_fee_rule.id,
+          amount_cents: resolved_amount_cents,
+          gl_account_id: resolved_gl_account_id,
+          business_date: request.business_date,
+          idempotency_key: request.idempotency_key
+        }
+      end
+
+      private
+
+      def validate_amount_override!
+        return if request.amount_cents.blank?
+        raise ValidationError, "Fee amount override must be positive" if request.amount_cents <= 0
+      end
+
+      def active_account!
+        @active_account ||= super(request.account_id)
+      end
+
+      def active_fee_type!
+        @active_fee_type ||= super
+      end
+
+      def resolve_fee_rule!
+        @resolved_fee_rule ||= FeeRule
+          .where(account_product_id: active_account!.account_product_id, fee_type_id: active_fee_type!.id)
+          .active_on(request.business_date)
+          .ordered
+          .first
+
+        raise ValidationError, "No active fee rule for #{active_fee_type!.code} on the selected account product" unless @resolved_fee_rule
+
+        @resolved_fee_rule
+      end
+
+      def resolved_fee_rule
+        @resolved_fee_rule || resolve_fee_rule!
+      end
+
+      def resolved_gl_account_id
+        resolved_fee_rule.gl_account_id_for_posting
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/interest_accrual_policy.rb
+++ b/app/services/transaction_entry/policies/interest_accrual_policy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class InterestAccrualPolicy < BasePolicy
+      def validate!
+        super
+        account = active_account!(request.account_id)
+        raise ValidationError, "Selected account is not interest-bearing" unless account.deposit_account&.interest_bearing?
+        require_field!(:accrual_date, "Accrual date is required for interest accrual")
+        raise ValidationError, "Interest accrual amount must be non-negative" if request.amount_cents.present? && request.amount_cents.negative?
+
+        active_interest_rule!(account)
+        self
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/interest_post_policy.rb
+++ b/app/services/transaction_entry/policies/interest_post_policy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class InterestPostPolicy < BasePolicy
+      def validate!
+        super
+        account = active_account!(request.account_id)
+        raise ValidationError, "Selected account is not interest-bearing" unless account.deposit_account&.interest_bearing?
+        require_field!(:posting_cycle, "Posting cycle is required for interest posting")
+        validate_positive_amount!
+        active_interest_rule!(account)
+        self
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/reversal_policy.rb
+++ b/app/services/transaction_entry/policies/reversal_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class ReversalPolicy < BasePolicy
+      def validate!
+        super
+        require_field!(:reversal_target_transaction_id, "Original transaction is required for reversals")
+        self
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policies/transfer_policy.rb
+++ b/app/services/transaction_entry/policies/transfer_policy.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  module Policies
+    class TransferPolicy < BasePolicy
+      def validate!
+        super
+        source_account = active_account!(request.source_account_id)
+        destination_account = active_account!(request.destination_account_id)
+        validate_positive_amount!
+        raise ValidationError, "Source and destination accounts must differ" if source_account.id == destination_account.id
+        raise ValidationError, "Transfer accounts must use the same currency" if source_account.currency_code != destination_account.currency_code
+
+        require_one_of!(:memo, :reference_number)
+        self
+      end
+
+      def preview_context_rows
+        [
+          [ "Transfer Mode", "Internal account transfer" ],
+          [ "Contra Context", "Preview should show both source and destination accounts before posting." ]
+        ]
+      end
+    end
+  end
+end

--- a/app/services/transaction_entry/policy_registry.rb
+++ b/app/services/transaction_entry/policy_registry.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  class PolicyRegistry
+    def self.build(request)
+      klass = case request.family
+      when :adjustment
+        TransactionEntry::Policies::AdjustmentPolicy
+      when :transfer
+        TransactionEntry::Policies::TransferPolicy
+      when :fee
+        TransactionEntry::Policies::FeePolicy
+      when :interest_accrual
+        TransactionEntry::Policies::InterestAccrualPolicy
+      when :interest_post
+        TransactionEntry::Policies::InterestPostPolicy
+      when :ach
+        TransactionEntry::Policies::AchPolicy
+      when :reversal
+        TransactionEntry::Policies::ReversalPolicy
+      else
+        raise UnsupportedTransactionError, "Unsupported transaction code #{request.transaction_code.inspect}"
+      end
+
+      klass.new(request)
+    end
+  end
+end

--- a/app/services/transaction_entry/preview_service.rb
+++ b/app/services/transaction_entry/preview_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  class PreviewService
+    def self.preview!(request:)
+      Dispatcher.preview!(request: request)
+    end
+  end
+end

--- a/app/services/transaction_entry/request.rb
+++ b/app/services/transaction_entry/request.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module TransactionEntry
+  class Request
+    MANUAL_ENTRY_CODES = %w[
+      ADJ_CREDIT
+      ADJ_DEBIT
+      XFER_INTERNAL
+      FEE_POST
+      ACH_CREDIT
+      ACH_DEBIT
+    ].freeze
+
+    attr_reader :transaction_code, :account_id, :source_account_id, :destination_account_id,
+      :amount, :amount_cents, :memo, :reason_text, :reference_number, :external_reference,
+      :idempotency_key, :created_by_id, :business_date, :fee_type_id, :fee_rule_id,
+      :original_fee_assessment_id, :interest_rule_id, :accrual_date, :posting_cycle,
+      :ach_trace_number, :ach_effective_date, :ach_batch_reference,
+      :authorization_reference, :authorization_source, :override_request_id,
+      :reversal_target_transaction_id, :gl_account_id
+
+    def self.from_form(raw_params:, created_by_id:, business_date: nil)
+      new(
+        transaction_code: normalize_string(raw_params[:transaction_code]),
+        account_id: normalize_integer(raw_params[:account_id]),
+        source_account_id: normalize_integer(raw_params[:source_account_id]),
+        destination_account_id: normalize_integer(raw_params[:destination_account_id]),
+        amount: normalize_string(raw_params[:amount]),
+        amount_cents: normalize_amount(raw_params[:amount]),
+        memo: normalize_string(raw_params[:memo]),
+        reason_text: normalize_string(raw_params[:reason_text]),
+        reference_number: normalize_string(raw_params[:reference_number]),
+        external_reference: normalize_string(raw_params[:external_reference]),
+        idempotency_key: normalize_string(raw_params[:idempotency_key]),
+        created_by_id: created_by_id,
+        business_date: business_date || BusinessDateService.current,
+        fee_type_id: normalize_integer(raw_params[:fee_type_id]),
+        fee_rule_id: normalize_integer(raw_params[:fee_rule_id]),
+        original_fee_assessment_id: normalize_integer(raw_params[:original_fee_assessment_id]),
+        interest_rule_id: normalize_integer(raw_params[:interest_rule_id]),
+        accrual_date: normalize_date(raw_params[:accrual_date]),
+        posting_cycle: normalize_string(raw_params[:posting_cycle]),
+        ach_trace_number: normalize_string(raw_params[:ach_trace_number]),
+        ach_effective_date: normalize_date(raw_params[:ach_effective_date]),
+        ach_batch_reference: normalize_string(raw_params[:ach_batch_reference]),
+        authorization_reference: normalize_string(raw_params[:authorization_reference]),
+        authorization_source: normalize_string(raw_params[:authorization_source]),
+        override_request_id: normalize_integer(raw_params[:override_request_id]),
+        reversal_target_transaction_id: normalize_integer(raw_params[:reversal_target_transaction_id]),
+        gl_account_id: normalize_integer(raw_params[:gl_account_id])
+      )
+    end
+
+    def self.normalize_string(value)
+      value.respond_to?(:strip) ? value.strip.presence : value.presence
+    end
+
+    def self.normalize_integer(value)
+      return nil if normalize_string(value).blank?
+
+      value.to_i
+    end
+
+    def self.normalize_amount(value)
+      return nil if normalize_string(value).blank?
+
+      (value.to_d * 100).round
+    end
+
+    def self.normalize_date(value)
+      return nil if normalize_string(value).blank?
+
+      value.to_date
+    rescue ArgumentError
+      nil
+    end
+
+    def initialize(**attrs)
+      attrs.each do |key, value|
+        instance_variable_set("@#{key}", value)
+      end
+    end
+
+    def family
+      case transaction_code
+      when "ADJ_CREDIT", "ADJ_DEBIT"
+        :adjustment
+      when "XFER_INTERNAL"
+        :transfer
+      when "FEE_POST"
+        :fee
+      when "INT_ACCRUAL"
+        :interest_accrual
+      when "INT_POST"
+        :interest_post
+      when "ACH_CREDIT", "ACH_DEBIT"
+        :ach
+      when /\A.*_REVERSAL\z/
+        :reversal
+      else
+        :unknown
+      end
+    end
+
+    def manual_entry_code?
+      MANUAL_ENTRY_CODES.include?(transaction_code)
+    end
+
+    def to_form_params
+      {
+        transaction_code: transaction_code,
+        account_id: account_id,
+        source_account_id: source_account_id,
+        destination_account_id: destination_account_id,
+        amount: amount,
+        memo: memo,
+        reason_text: reason_text,
+        reference_number: reference_number,
+        external_reference: external_reference,
+        idempotency_key: idempotency_key,
+        fee_type_id: fee_type_id,
+        fee_rule_id: fee_rule_id,
+        original_fee_assessment_id: original_fee_assessment_id,
+        interest_rule_id: interest_rule_id,
+        accrual_date: accrual_date&.iso8601,
+        posting_cycle: posting_cycle,
+        ach_trace_number: ach_trace_number,
+        ach_effective_date: ach_effective_date&.iso8601,
+        ach_batch_reference: ach_batch_reference,
+        authorization_reference: authorization_reference,
+        authorization_source: authorization_source,
+        override_request_id: override_request_id,
+        reversal_target_transaction_id: reversal_target_transaction_id
+      }.compact
+    end
+
+    def preview_metadata
+      {
+        memo: memo,
+        reason_text: reason_text,
+        reference_number: reference_number,
+        external_reference: external_reference,
+        idempotency_key: idempotency_key
+      }.compact
+    end
+  end
+end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -64,6 +64,7 @@
         <%= link_to "Place Hold", new_account_account_hold_path(@account), class: "btn btn-outline btn-sm" %>
         <%= link_to "Fee History", fee_assessments_path(account_id: @account.id), class: "btn btn-ghost btn-sm" %>
         <%= link_to "Accrual History", interest_accruals_path(account_id: @account.id), class: "btn btn-ghost btn-sm" %>
+        <%= link_to "Interest Posting", interest_postings_path, class: "btn btn-ghost btn-sm" %>
       </div>
     </div>
   </section>

--- a/app/views/interest_accruals/index.html.erb
+++ b/app/views/interest_accruals/index.html.erb
@@ -14,6 +14,42 @@
   <section class="ui-panel">
     <div class="ui-panel-header">
       <div>
+        <h2 class="text-lg font-semibold text-base-content">Accrual Workbench</h2>
+        <p class="mt-1 text-sm text-base-content/65">Daily accrual runs use the current business date and active product rules.</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <span class="ui-status-pill ui-status-pill-neutral"><%= @business_date&.strftime("%Y-%m-%d") %></span>
+        <%= button_to "Run Daily Accrual", run_interest_accruals_path, method: :post, class: "btn btn-primary btn-sm" %>
+      </div>
+    </div>
+
+    <div class="ui-panel-body space-y-4">
+      <div class="grid gap-4 lg:grid-cols-2">
+        <% @active_interest_rules.each do |rule| %>
+          <div class="rounded-2xl border border-base-300/70 px-4 py-3">
+            <div class="text-sm font-semibold text-base-content"><%= rule.account_product.name %></div>
+            <div class="mt-1 text-sm text-base-content/70">Rate <span class="ui-mono"><%= number_to_percentage(rule.rate.to_d * 100, precision: 2) %></span></div>
+            <div class="mt-1 text-sm text-base-content/70">Day Count <span class="ui-mono"><%= rule.day_count_method %></span></div>
+          </div>
+        <% end %>
+      </div>
+
+      <% if @run_results.present? %>
+        <div class="rounded-2xl border border-base-300/70 px-4 py-4">
+          <div class="text-sm font-semibold text-base-content">Latest Run Summary</div>
+          <div class="mt-3 grid gap-4 lg:grid-cols-3 text-sm">
+            <div>Accrued: <span class="ui-mono"><%= @run_results[:accrued].size %></span></div>
+            <div>Skipped: <span class="ui-mono"><%= @run_results[:skipped].size %></span></div>
+            <div>Errors: <span class="ui-mono"><%= @run_results[:errors].size %></span></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <section class="ui-panel mt-6">
+    <div class="ui-panel-header">
+      <div>
         <h2 class="text-lg font-semibold text-base-content">Accrual Register</h2>
         <p class="mt-1 text-sm text-base-content/65"><%= account_filter ? "Filtered to account ##{account_filter}." : "Recent accrual activity across interest-bearing accounts." %></p>
       </div>

--- a/app/views/interest_postings/index.html.erb
+++ b/app/views/interest_postings/index.html.erb
@@ -1,0 +1,90 @@
+<% content_for :title, "Interest Posting - BankCORE" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back", root_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Interest Posting</h1>
+      <p class="workspace-subtitle">Cycle-aware posting batches sum unposted accruals and link each accrual to the resulting posting batch.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Posting Workbench</h2>
+        <p class="mt-1 text-sm text-base-content/65">Only accrued balances due on the current business date will be posted.</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <span class="ui-status-pill ui-status-pill-neutral"><%= @business_date&.strftime("%Y-%m-%d") %></span>
+        <%= button_to "Post Due Interest", interest_postings_path, method: :post, class: "btn btn-primary btn-sm" %>
+      </div>
+    </div>
+
+    <div class="ui-panel-body space-y-4">
+      <div class="grid gap-4 lg:grid-cols-3">
+        <div class="ui-metric">
+          <div class="ui-metric-label">Due Accounts</div>
+          <div class="ui-metric-value ui-mono"><%= @due_accounts.size %></div>
+        </div>
+        <div class="ui-metric">
+          <div class="ui-metric-label">Accrual Items</div>
+          <div class="ui-metric-value ui-mono"><%= @due_accounts.sum { |entry| entry[:accrual_count] } %></div>
+        </div>
+        <div class="ui-metric">
+          <div class="ui-metric-label">Amount Ready</div>
+          <div class="ui-metric-value ui-mono"><%= number_to_currency(@due_accounts.sum { |entry| entry[:amount_cents] } / 100.0) %></div>
+        </div>
+      </div>
+
+      <% if @run_results.present? %>
+        <div class="rounded-2xl border border-base-300/70 px-4 py-4">
+          <div class="text-sm font-semibold text-base-content">Latest Run Summary</div>
+          <div class="mt-3 grid gap-4 lg:grid-cols-3 text-sm">
+            <div>Posted: <span class="ui-mono"><%= @run_results[:posted].size %></span></div>
+            <div>Skipped: <span class="ui-mono"><%= @run_results[:skipped].size %></span></div>
+            <div>Errors: <span class="ui-mono"><%= @run_results[:errors].size %></span></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <section class="ui-panel mt-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Due Accounts</h2>
+        <p class="mt-1 text-sm text-base-content/65">Accounts with unposted accruals available for the current posting cycle.</p>
+      </div>
+    </div>
+
+    <div class="ui-panel-body">
+      <table class="ui-ledger-table">
+        <thead>
+          <tr>
+            <th>Account</th>
+            <th>Product</th>
+            <th>Cadence</th>
+            <th class="text-right">Accruals</th>
+            <th class="text-right">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @due_accounts.each do |entry| %>
+            <tr>
+              <td><%= link_to entry[:account].account_number, account_path(entry[:account]), class: "link link-primary ui-mono" %></td>
+              <td><%= entry[:account].account_product&.name %></td>
+              <td class="ui-mono"><%= entry[:posting_cadence] %></td>
+              <td class="ui-mono text-right"><%= entry[:accrual_count] %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(entry[:amount_cents] / 100.0) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <% if @due_accounts.empty? %>
+        <p class="mt-4 text-sm text-base-content/60">No due accounts with unposted accruals for the current business date.</p>
+      <% end %>
+    </div>
+  </section>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,6 +83,9 @@
               <%= link_to interest_accruals_path, class: app_nav_link_class(interest_accruals_path) do %>
                 <span>Interest Accruals</span>
               <% end %>
+              <%= link_to interest_postings_path, class: app_nav_link_class(interest_postings_path) do %>
+                <span>Interest Postings</span>
+              <% end %>
               <%= link_to audit_events_path, class: app_nav_link_class(audit_events_path) do %>
                 <span>Audit Events</span>
               <% end %>

--- a/app/views/transactions/_ach_fields.html.erb
+++ b/app/views/transactions/_ach_fields.html.erb
@@ -1,0 +1,36 @@
+<div id="ach_fields" class="hidden grid gap-4 lg:grid-cols-2">
+  <div class="form-control w-full">
+    <label class="label" for="ach_trace_number">
+      <span class="label-text text-sm font-medium">ACH Trace Number</span>
+    </label>
+    <input type="text" name="transaction[ach_trace_number]" id="ach_trace_number" value="<%= params.dig(:transaction, :ach_trace_number) %>" class="input input-bordered w-full ui-mono" placeholder="15-digit trace number">
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="ach_effective_date">
+      <span class="label-text text-sm font-medium">Effective Date</span>
+    </label>
+    <input type="date" name="transaction[ach_effective_date]" id="ach_effective_date" value="<%= params.dig(:transaction, :ach_effective_date) %>" class="input input-bordered w-full ui-mono">
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="ach_batch_reference">
+      <span class="label-text text-sm font-medium">Batch / File Reference</span>
+    </label>
+    <input type="text" name="transaction[ach_batch_reference]" id="ach_batch_reference" value="<%= params.dig(:transaction, :ach_batch_reference) %>" class="input input-bordered w-full ui-mono" placeholder="ACH batch or file ID">
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="authorization_reference">
+      <span class="label-text text-sm font-medium">Authorization Reference</span>
+    </label>
+    <input type="text" name="transaction[authorization_reference]" id="authorization_reference" value="<%= params.dig(:transaction, :authorization_reference) %>" class="input input-bordered w-full ui-mono" placeholder="Required for ACH debits">
+  </div>
+
+  <div class="form-control w-full lg:col-span-2">
+    <label class="label" for="authorization_source">
+      <span class="label-text text-sm font-medium">Authorization Source</span>
+    </label>
+    <input type="text" name="transaction[authorization_source]" id="authorization_source" value="<%= params.dig(:transaction, :authorization_source) %>" class="input input-bordered w-full" placeholder="e.g. signed form, online mandate, verbal confirmation">
+  </div>
+</div>

--- a/app/views/transactions/_adjustment_fields.html.erb
+++ b/app/views/transactions/_adjustment_fields.html.erb
@@ -1,0 +1,5 @@
+<div id="adjustment_fields" class="hidden">
+  <div class="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-base-content/80">
+    Manual adjustments require a reason and reference number. Debit adjustments should only be used when the customer-side correction is fully understood and traceable.
+  </div>
+</div>

--- a/app/views/transactions/_fee_fields.html.erb
+++ b/app/views/transactions/_fee_fields.html.erb
@@ -1,0 +1,19 @@
+<div id="fee_fields" class="hidden space-y-4">
+  <div class="grid gap-4 lg:grid-cols-2">
+    <div class="form-control w-full">
+      <label class="label" for="fee_type_id">
+        <span class="label-text text-sm font-medium">Fee Type</span>
+      </label>
+      <select name="transaction[fee_type_id]" id="fee_type_id" class="select select-bordered w-full">
+        <option value="">— Select fee type —</option>
+        <% @fee_types.each do |fee_type| %>
+          <option value="<%= fee_type.id %>" <%= "selected" if params.dig(:transaction, :fee_type_id).to_i == fee_type.id %>><%= fee_type.code %> — <%= fee_type.name %></option>
+        <% end %>
+      </select>
+    </div>
+
+    <div class="rounded-2xl border border-sky-400/25 bg-sky-500/10 px-4 py-3 text-sm text-base-content/80">
+      Fee posting resolves the active fee rule for the selected account product. Leave amount blank to use the rule-driven amount or fee-type default.
+    </div>
+  </div>
+</div>

--- a/app/views/transactions/_shared_metadata_fields.html.erb
+++ b/app/views/transactions/_shared_metadata_fields.html.erb
@@ -1,0 +1,36 @@
+<div class="grid gap-4 lg:grid-cols-2">
+  <div class="form-control w-full lg:col-span-2">
+    <label class="label" for="memo">
+      <span class="label-text text-sm font-medium">Memo</span>
+    </label>
+    <textarea name="transaction[memo]" id="memo" class="textarea textarea-bordered w-full" rows="3" placeholder="Operator-visible summary for account history and transaction review"><%= params.dig(:transaction, :memo) %></textarea>
+  </div>
+
+  <div class="form-control w-full lg:col-span-2">
+    <label class="label" for="reason_text">
+      <span class="label-text text-sm font-medium">Reason / Justification</span>
+    </label>
+    <textarea name="transaction[reason_text]" id="reason_text" class="textarea textarea-bordered w-full" rows="2" placeholder="Why this transaction is being entered"><%= params.dig(:transaction, :reason_text) %></textarea>
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="reference_number">
+      <span class="label-text text-sm font-medium">Reference Number</span>
+    </label>
+    <input type="text" name="transaction[reference_number]" id="reference_number" value="<%= params.dig(:transaction, :reference_number) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. MAN-20260309-001">
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="external_reference">
+      <span class="label-text text-sm font-medium">External Reference</span>
+    </label>
+    <input type="text" name="transaction[external_reference]" id="external_reference" value="<%= params.dig(:transaction, :external_reference) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. case ID, network reference, ticket">
+  </div>
+
+  <div class="form-control w-full lg:col-span-2">
+    <label class="label" for="idempotency_key">
+      <span class="label-text text-sm font-medium">Idempotency Key</span>
+    </label>
+    <input type="text" name="transaction[idempotency_key]" id="idempotency_key" value="<%= params.dig(:transaction, :idempotency_key) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. manual-20260307-001">
+  </div>
+</div>

--- a/app/views/transactions/_transfer_fields.html.erb
+++ b/app/views/transactions/_transfer_fields.html.erb
@@ -1,0 +1,25 @@
+<div id="transfer_fields" class="hidden grid gap-4 lg:grid-cols-2">
+  <div class="form-control w-full">
+    <label class="label" for="source_account_id">
+      <span class="label-text text-sm font-medium">From Account</span>
+    </label>
+    <select name="transaction[source_account_id]" id="source_account_id" class="select select-bordered w-full ui-mono">
+      <option value="">— Select account —</option>
+      <% @accounts.each do |acc| %>
+        <option value="<%= acc.id %>" <%= "selected" if params.dig(:transaction, :source_account_id).to_i == acc.id %>><%= acc.account_number %> — <%= acc.account_product&.product_code %></option>
+      <% end %>
+    </select>
+  </div>
+
+  <div class="form-control w-full">
+    <label class="label" for="destination_account_id">
+      <span class="label-text text-sm font-medium">To Account</span>
+    </label>
+    <select name="transaction[destination_account_id]" id="destination_account_id" class="select select-bordered w-full ui-mono">
+      <option value="">— Select account —</option>
+      <% @accounts.each do |acc| %>
+        <option value="<%= acc.id %>" <%= "selected" if params.dig(:transaction, :destination_account_id).to_i == acc.id %>><%= acc.account_number %> — <%= acc.account_product&.product_code %></option>
+      <% end %>
+    </select>
+  </div>
+</div>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -4,8 +4,8 @@
   <div class="workspace-header">
     <div>
       <%= link_to "← Back to Transactions", transactions_path, class: "link link-primary mb-2 inline-block text-sm" %>
-      <h1 class="workspace-title">Manual Transaction Entry</h1>
-      <p class="workspace-subtitle">Capture a governed back-office transaction, preview the balanced posting legs, and commit only after review.</p>
+      <h1 class="workspace-title">Transaction Workstation</h1>
+      <p class="workspace-subtitle">Use the shared shell for adjustments, transfers, fees, and ACH. Interest workflows and reversals use dedicated operator workbenches.</p>
     </div>
   </div>
 
@@ -31,7 +31,7 @@
             </div>
             <div class="ui-kv-row">
               <div class="ui-kv-label">Workflow Mode</div>
-              <div id="transaction_guidance" class="ui-kv-value">Choose a transaction code to load the required account controls.</div>
+              <div id="transaction_guidance" class="ui-kv-value">Choose a transaction code to load the required controls.</div>
             </div>
           </div>
         </div>
@@ -39,18 +39,24 @@
 
       <section class="ui-panel-muted">
         <div class="ui-panel-header">
-          <h2 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Posting Rules</h2>
+          <h2 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Shared Rules</h2>
         </div>
         <div class="ui-panel-body space-y-3 text-sm text-base-content/75">
-          <p>All entries fail closed if the posting batch is unbalanced, a ledger target is missing, or the business date is not open.</p>
-          <p>Preview before commit if you want to inspect the derived debit and credit legs before posting.</p>
+          <p>All workstation submissions fail closed if the business date is closed, the amount is invalid, or the routing targets do not resolve.</p>
+          <p>Preview lets you inspect the derived posting legs before any operational transaction or side record is created.</p>
         </div>
       </section>
 
-      <section class="ui-override-box">
-        <div class="space-y-2">
-          <div class="text-sm font-semibold text-base-content">Exception Handling</div>
-          <p class="text-sm text-base-content/80">Override workflows remain explicit and auditable. Controlled actions such as governed reversals are routed through the approval path instead of silently bypassing validation.</p>
+      <section class="ui-panel">
+        <div class="ui-panel-header">
+          <h2 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Dedicated Workbenches</h2>
+        </div>
+        <div class="ui-panel-body space-y-3">
+          <%= link_to "Run Interest Accrual", interest_accruals_path, class: "btn btn-outline w-full justify-start" %>
+          <%= link_to "Run Interest Posting", interest_postings_path, class: "btn btn-outline w-full justify-start" %>
+          <div class="rounded-2xl border border-base-300/70 px-4 py-3 text-sm text-base-content/75">
+            Reversals are previewed and confirmed from each transaction review screen so override thresholds stay explicit.
+          </div>
         </div>
       </section>
     </div>
@@ -59,8 +65,8 @@
       <section class="ui-panel">
         <div class="ui-panel-header">
           <div>
-            <h2 class="text-lg font-semibold text-base-content">Transaction Definition</h2>
-            <p class="mt-1 text-sm text-base-content/65">Enter the transaction details, then preview or post the resulting batch.</p>
+            <h2 class="text-lg font-semibold text-base-content">Shared Transaction Shell</h2>
+            <p class="mt-1 text-sm text-base-content/65">The policy layer validates family-specific inputs before previewing or dispatching to the correct posting path.</p>
           </div>
         </div>
 
@@ -76,7 +82,7 @@
             </div>
           <% end %>
 
-          <%= form_with url: transactions_path, method: :post, local: true, class: "space-y-5" do |f| %>
+          <%= form_with url: transactions_path, method: :post, local: true, class: "space-y-5" do %>
             <section class="ui-form-section">
               <div>
                 <h3 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Posting Instruction</h3>
@@ -97,7 +103,7 @@
 
                 <div class="form-control w-full">
                   <label class="label" for="amount">
-                    <span class="label-text text-sm font-medium">Amount (USD)</span>
+                    <span id="amount_label" class="label-text text-sm font-medium">Amount (USD)</span>
                   </label>
                   <input type="number" name="transaction[amount]" id="amount" step="0.01" min="0" value="<%= params.dig(:transaction, :amount) %>" class="input input-bordered w-full ui-mono text-lg" placeholder="0.00" required>
                 </div>
@@ -116,36 +122,23 @@
                 <select name="transaction[account_id]" id="account_id" class="select select-bordered w-full ui-mono" data-preselected-account="<%= @preselected_account_id || params.dig(:transaction, :account_id) %>">
                   <option value="">— Select account —</option>
                   <% @accounts.each do |acc| %>
-                    <option value="<%= acc.id %>" <%= "selected" if (@preselected_account_id.to_i == acc.id || params.dig(:transaction, :account_id).to_i == acc.id) %>><%= acc.account_number %> — <%= acc.status %></option>
+                    <option value="<%= acc.id %>" <%= "selected" if (@preselected_account_id.to_i == acc.id || params.dig(:transaction, :account_id).to_i == acc.id) %>><%= acc.account_number %> — <%= acc.account_product&.product_code %> — <%= acc.status %></option>
                   <% end %>
                 </select>
               </div>
 
-              <div id="transfer_fields" class="hidden grid gap-4 lg:grid-cols-2">
-                <div class="form-control w-full">
-                  <label class="label" for="source_account_id">
-                    <span class="label-text text-sm font-medium">From Account</span>
-                  </label>
-                  <select name="transaction[source_account_id]" id="source_account_id" class="select select-bordered w-full ui-mono">
-                    <option value="">— Select account —</option>
-                    <% @accounts.each do |acc| %>
-                      <option value="<%= acc.id %>" <%= "selected" if params.dig(:transaction, :source_account_id).to_i == acc.id %>><%= acc.account_number %></option>
-                    <% end %>
-                  </select>
-                </div>
+              <%= render "transactions/transfer_fields" %>
+            </section>
 
-                <div class="form-control w-full">
-                  <label class="label" for="destination_account_id">
-                    <span class="label-text text-sm font-medium">To Account</span>
-                  </label>
-                  <select name="transaction[destination_account_id]" id="destination_account_id" class="select select-bordered w-full ui-mono">
-                    <option value="">— Select account —</option>
-                    <% @accounts.each do |acc| %>
-                      <option value="<%= acc.id %>" <%= "selected" if params.dig(:transaction, :destination_account_id).to_i == acc.id %>><%= acc.account_number %></option>
-                    <% end %>
-                  </select>
-                </div>
+            <section class="ui-form-section space-y-4">
+              <div>
+                <h3 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Family Controls</h3>
+                <p class="mt-1 text-sm text-base-content/65">Select a transaction type to load any family-specific controls that apply.</p>
               </div>
+
+              <%= render "transactions/adjustment_fields" %>
+              <%= render "transactions/fee_fields" %>
+              <%= render "transactions/ach_fields" %>
             </section>
 
             <section class="ui-form-section">
@@ -153,50 +146,15 @@
                 <h3 class="text-sm font-semibold uppercase tracking-[0.16em] text-base-content/60">Control Metadata</h3>
               </div>
 
-              <div class="grid gap-4 lg:grid-cols-2">
-                <div class="form-control w-full lg:col-span-2">
-                  <label class="label" for="memo">
-                    <span class="label-text text-sm font-medium">Memo</span>
-                  </label>
-                  <textarea name="transaction[memo]" id="memo" class="textarea textarea-bordered w-full" rows="3" placeholder="Operator-visible summary for account history and transaction review"><%= params.dig(:transaction, :memo) %></textarea>
-                </div>
-
-                <div class="form-control w-full lg:col-span-2">
-                  <label class="label" for="reason_text">
-                    <span class="label-text text-sm font-medium">Reason / Justification</span>
-                  </label>
-                  <textarea name="transaction[reason_text]" id="reason_text" class="textarea textarea-bordered w-full" rows="2" placeholder="Why this transaction is being entered"><%= params.dig(:transaction, :reason_text) %></textarea>
-                </div>
-
-                <div class="form-control w-full">
-                  <label class="label" for="reference_number">
-                    <span class="label-text text-sm font-medium">Reference Number</span>
-                  </label>
-                  <input type="text" name="transaction[reference_number]" id="reference_number" value="<%= params.dig(:transaction, :reference_number) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. MAN-20260309-001">
-                </div>
-
-                <div class="form-control w-full">
-                  <label class="label" for="external_reference">
-                    <span class="label-text text-sm font-medium">External Reference</span>
-                  </label>
-                  <input type="text" name="transaction[external_reference]" id="external_reference" value="<%= params.dig(:transaction, :external_reference) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. case ID, ACH trace, ticket">
-                </div>
-
-                <div class="form-control w-full lg:col-span-2">
-                  <label class="label" for="idempotency_key">
-                    <span class="label-text text-sm font-medium">Idempotency Key</span>
-                  </label>
-                  <input type="text" name="transaction[idempotency_key]" id="idempotency_key" value="<%= params.dig(:transaction, :idempotency_key) %>" class="input input-bordered w-full ui-mono" placeholder="e.g. manual-20260307-001">
-                </div>
-              </div>
+              <%= render "transactions/shared_metadata_fields" %>
             </section>
 
             <div class="ui-review-banner">
-              Preview lets you inspect the planned ledger impact before commit. Posting immediately will create the operational transaction and the balanced posting batch in one controlled step.
+              Preview lets you inspect the planned ledger impact before commit. Posting immediately will create the operational transaction and the family-specific side effects in one controlled step.
             </div>
 
             <div class="ui-confirm-strip">
-              <p class="max-w-2xl text-sm text-base-content/70">Commit actions are deliberate. Posting will fail closed if any target, amount, or business-date validation does not pass.</p>
+              <p class="max-w-2xl text-sm text-base-content/70">Commit actions are deliberate. The dispatcher will route shared-shell transactions through the correct family path after policy validation.</p>
               <div class="flex flex-wrap items-center gap-2">
                 <button type="submit" name="preview" value="1" class="btn btn-outline">Preview Posting</button>
                 <button type="submit" class="btn btn-primary">Post Transaction</button>
@@ -211,22 +169,45 @@
 </div>
 
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
+  function initializeTransactionWorkstation() {
     const typeSelect = document.getElementById('transaction_code');
+    if (!typeSelect) return;
+
     const accountFields = document.getElementById('account_fields');
     const transferFields = document.getElementById('transfer_fields');
+    const adjustmentFields = document.getElementById('adjustment_fields');
+    const feeFields = document.getElementById('fee_fields');
+    const achFields = document.getElementById('ach_fields');
     const accountSelect = document.getElementById('account_id');
     const sourceSelect = document.getElementById('source_account_id');
     const destSelect = document.getElementById('destination_account_id');
+    const amountInput = document.getElementById('amount');
+    const amountLabel = document.getElementById('amount_label');
     const selectedAccountContext = document.getElementById('selected_account_context');
     const guidance = document.getElementById('transaction_guidance');
+    const feeTypeSelect = document.getElementById('fee_type_id');
+    const achTrace = document.getElementById('ach_trace_number');
+    const achEffectiveDate = document.getElementById('ach_effective_date');
+    const achBatch = document.getElementById('ach_batch_reference');
+    const authRef = document.getElementById('authorization_reference');
 
     const TRANSFER_TYPES = ['XFER_INTERNAL'];
-    const GL_ONLY_TYPES = ['INT_ACCRUAL'];
+    const ADJUSTMENT_TYPES = ['ADJ_CREDIT', 'ADJ_DEBIT'];
+    const FEE_TYPES = ['FEE_POST'];
+    const ACH_TYPES = ['ACH_CREDIT', 'ACH_DEBIT'];
 
     function selectedText(select) {
-      const option = select.options[select.selectedIndex];
+      const option = select && select.options[select.selectedIndex];
       return option && option.value ? option.text : null;
+    }
+
+    function toggleRequired(field, required) {
+      if (!field) return;
+      if (required) {
+        field.setAttribute('required', 'required');
+      } else {
+        field.removeAttribute('required');
+      }
     }
 
     function updateContext(code) {
@@ -234,42 +215,70 @@
         const fromAccount = selectedText(sourceSelect);
         const toAccount = selectedText(destSelect);
         selectedAccountContext.textContent = [fromAccount, toAccount].filter(Boolean).join(' → ') || 'Select both transfer accounts';
-        guidance.textContent = 'Internal transfer mode. Both source and destination accounts are required before preview or post.';
-      } else if (GL_ONLY_TYPES.includes(code)) {
-        selectedAccountContext.textContent = 'No customer account required';
-        guidance.textContent = 'GL-only posting mode. Customer account routing is intentionally disabled for this transaction code.';
+        guidance.textContent = 'Internal transfer mode. Both accounts must be active and use the same currency.';
       } else {
         selectedAccountContext.textContent = selectedText(accountSelect) || 'Waiting for account selection';
-        guidance.textContent = code ? 'Customer account mode. One active account will receive the debit or credit leg.' : 'Choose a transaction code to load the required account controls.';
+        if (ADJUSTMENT_TYPES.includes(code)) {
+          guidance.textContent = 'Adjustment mode. Reason and reference capture are required before preview or post.';
+        } else if (FEE_TYPES.includes(code)) {
+          guidance.textContent = 'Fee mode. The dispatcher will resolve the active fee rule for the selected account product.';
+        } else if (ACH_TYPES.includes(code)) {
+          guidance.textContent = 'ACH mode. Trace, effective date, and batch references are captured as structured transaction references.';
+        } else {
+          guidance.textContent = 'Choose a transaction code to load the required controls.';
+        }
       }
     }
 
     function updateFields() {
       const code = typeSelect.value;
-      if (TRANSFER_TYPES.includes(code)) {
-        accountFields.classList.add('hidden');
-        transferFields.classList.remove('hidden');
-        accountSelect.removeAttribute('required');
-        accountSelect.value = '';
-        sourceSelect.setAttribute('required', 'required');
-        destSelect.setAttribute('required', 'required');
-      } else if (GL_ONLY_TYPES.includes(code)) {
-        accountFields.classList.add('hidden');
-        transferFields.classList.add('hidden');
-        accountSelect.removeAttribute('required');
-        accountSelect.value = '';
-        sourceSelect.removeAttribute('required');
-        destSelect.removeAttribute('required');
+      const isTransfer = TRANSFER_TYPES.includes(code);
+      const isAdjustment = ADJUSTMENT_TYPES.includes(code);
+      const isFee = FEE_TYPES.includes(code);
+      const isAch = ACH_TYPES.includes(code);
+      const isAchDebit = code === 'ACH_DEBIT';
+
+      accountFields.classList.toggle('hidden', isTransfer);
+      transferFields.classList.toggle('hidden', !isTransfer);
+      adjustmentFields.classList.toggle('hidden', !isAdjustment);
+      feeFields.classList.toggle('hidden', !isFee);
+      achFields.classList.toggle('hidden', !isAch);
+
+      toggleRequired(accountSelect, !isTransfer);
+      toggleRequired(sourceSelect, isTransfer);
+      toggleRequired(destSelect, isTransfer);
+      toggleRequired(feeTypeSelect, isFee);
+      toggleRequired(achTrace, isAch);
+      toggleRequired(achEffectiveDate, isAch);
+      toggleRequired(achBatch, isAch);
+      toggleRequired(authRef, isAchDebit);
+
+      if (isFee) {
+        amountLabel.textContent = 'Amount Override (USD)';
+        amountInput.placeholder = 'Leave blank to use fee rule/default';
+        amountInput.removeAttribute('required');
+      } else {
+        amountLabel.textContent = 'Amount (USD)';
+        amountInput.placeholder = '0.00';
+        amountInput.setAttribute('required', 'required');
+      }
+
+      if (!isTransfer) {
         sourceSelect.value = '';
         destSelect.value = '';
       } else {
-        accountFields.classList.remove('hidden');
-        transferFields.classList.add('hidden');
-        accountSelect.setAttribute('required', 'required');
-        sourceSelect.removeAttribute('required');
-        destSelect.removeAttribute('required');
-        sourceSelect.value = '';
-        destSelect.value = '';
+        accountSelect.value = '';
+      }
+
+      if (!isAch) {
+        achTrace.value = '';
+        achEffectiveDate.value = '';
+        achBatch.value = '';
+        authRef.value = '';
+      }
+
+      if (!isFee) {
+        feeTypeSelect.value = '';
       }
 
       updateContext(code);
@@ -284,6 +293,10 @@
     if (preselectedId) {
       accountSelect.value = preselectedId;
     }
+
     updateFields();
-  });
+  }
+
+  document.addEventListener('turbo:load', initializeTransactionWorkstation);
+  document.addEventListener('DOMContentLoaded', initializeTransactionWorkstation);
 </script>

--- a/app/views/transactions/preview.html.erb
+++ b/app/views/transactions/preview.html.erb
@@ -19,6 +19,17 @@
     </div>
 
     <div class="ui-panel-body">
+      <% if @preview_context_rows.present? %>
+        <div class="ui-kv-grid mb-5">
+          <% @preview_context_rows.each do |label, value| %>
+            <div class="ui-kv-row">
+              <div class="ui-kv-label"><%= label %></div>
+              <div class="ui-kv-value"><%= value.presence || "—" %></div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
       <% if @preview_metadata.present? %>
         <div class="ui-kv-grid mb-5">
           <% if @preview_metadata[:memo].present? %>
@@ -43,6 +54,12 @@
             <div class="ui-kv-row">
               <div class="ui-kv-label">External Reference</div>
               <div class="ui-kv-value ui-mono"><%= @preview_metadata[:external_reference] %></div>
+            </div>
+          <% end %>
+          <% if @preview_metadata[:idempotency_key].present? %>
+            <div class="ui-kv-row">
+              <div class="ui-kv-label">Idempotency Key</div>
+              <div class="ui-kv-value ui-mono"><%= @preview_metadata[:idempotency_key] %></div>
             </div>
           <% end %>
         </div>

--- a/app/views/transactions/reverse_preview.html.erb
+++ b/app/views/transactions/reverse_preview.html.erb
@@ -1,0 +1,76 @@
+<% content_for :title, "Reverse Transaction ##{@transaction.id} - BankCORE" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Transaction Review", transaction_path(@transaction), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Reversal Preview</h1>
+      <p class="workspace-subtitle">Review the inverse posting legs before creating the controlled reversal batch.</p>
+    </div>
+  </div>
+
+  <% if @override_required %>
+    <section class="ui-override-box mb-6">
+      <div class="space-y-2">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="<%= status_pill_class('pending') %>">Override Required</span>
+          <span class="text-sm font-medium text-base-content">This reversal meets or exceeds <span class="ui-mono"><%= number_to_currency(@override_threshold_cents / 100.0) %></span>.</span>
+        </div>
+        <p class="text-sm text-base-content/80">If no approved override is already available, confirming the reversal will route you into the approval request flow.</p>
+      </div>
+    </section>
+  <% end %>
+
+  <section class="posting-preview-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Reverse <%= @transaction.transaction_type %></h2>
+        <p class="mt-1 text-sm text-base-content/65">Economic amount <span class="ui-mono font-semibold"><%= number_to_currency(@economic_amount_cents / 100.0) %></span></p>
+      </div>
+      <span class="<%= status_pill_class('review') %>">Explicit Confirmation</span>
+    </div>
+
+    <div class="ui-panel-body">
+      <table class="ui-ledger-table">
+        <thead>
+          <tr>
+            <th>Leg</th>
+            <th>Scope</th>
+            <th>Target</th>
+            <th class="text-right">Debit</th>
+            <th class="text-right">Credit</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @preview_legs.each do |leg| %>
+            <tr>
+              <td><span class="<%= leg_type_pill_class(leg[:leg_type]) %>"><%= leg[:leg_type] %></span></td>
+              <td class="text-sm text-base-content/70"><%= leg[:ledger_scope] %></td>
+              <td>
+                <% if leg[:account].present? %>
+                  <div class="font-medium text-base-content">Customer Account</div>
+                  <div class="ui-mono text-sm text-base-content/70"><%= leg[:account].account_number %></div>
+                <% elsif leg[:gl_account].present? %>
+                  <div class="font-medium text-base-content">GL Account</div>
+                  <div class="ui-mono text-sm text-base-content/70"><%= leg[:gl_account].gl_number %> — <%= leg[:gl_account].name %></div>
+                <% else %>
+                  —
+                <% end %>
+              </td>
+              <td class="ui-mono text-right"><%= leg[:leg_type] == "debit" ? number_to_currency(leg[:amount_cents] / 100.0) : "—" %></td>
+              <td class="ui-mono text-right"><%= leg[:leg_type] == "credit" ? number_to_currency(leg[:amount_cents] / 100.0) : "—" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <div class="ui-confirm-strip mt-5">
+        <p class="max-w-2xl text-sm text-base-content/70">Confirming will call the governed reversal flow. Existing override rules and idempotency protections remain in force.</p>
+        <div class="flex flex-wrap items-center gap-2">
+          <%= button_to "Confirm Reversal", reverse_transaction_path(@transaction), method: :post, class: "btn btn-error" %>
+          <%= link_to "Cancel", transaction_path(@transaction), class: "btn btn-ghost" %>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -40,11 +40,7 @@
 
       <% if reversible %>
         <div class="flex items-center gap-2">
-          <%= button_to "Reverse Transaction",
-              reverse_transaction_path(@transaction),
-              method: :post,
-              form: { data: { turbo_confirm: "Are you sure you want to reverse this transaction? This cannot be undone." } },
-              class: "btn btn-error btn-outline btn-sm" %>
+          <%= link_to "Preview Reversal", reverse_preview_transaction_path(@transaction), class: "btn btn-error btn-outline btn-sm" %>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
   root "transactions#index"
 
   resources :transactions, only: %i[index show new create] do
-    member { post :reverse }
+    member do
+      get :reverse_preview
+      post :reverse
+    end
   end
 
   resources :accounts, only: %i[index show new create] do
@@ -36,7 +39,10 @@ Rails.application.routes.draw do
 
   resources :fee_types, only: %i[index new create edit update], path: "fee-types"
   resources :fee_assessments, only: %i[index], path: "fee-assessments"
-  resources :interest_accruals, only: %i[index], path: "interest-accruals"
+  resources :interest_accruals, only: %i[index], path: "interest-accruals" do
+    collection { post :run }
+  end
+  resources :interest_postings, only: %i[index create], path: "interest-postings"
   resources :audit_events, only: %i[index], path: "audit-events"
   resources :branches, only: %i[index show]
   resources :gl_accounts, only: %i[index], path: "gl-accounts"

--- a/test/controllers/interest_accruals_controller_test.rb
+++ b/test/controllers/interest_accruals_controller_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InterestAccrualsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    post login_url, params: { username: "testuser", password: "secret" }
+    ensure_int_accrual_template!
+    deposit_account = DepositAccount.find_or_initialize_by(account_id: accounts(:two).id)
+    deposit_account.deposit_type ||= accounts(:two).account_product.default_deposit_type
+    deposit_account.interest_bearing = true
+    deposit_account.save!
+
+    balance = AccountBalance.find_or_initialize_by(account_id: accounts(:two).id)
+    balance.posted_balance_cents = 10_000
+    balance.available_balance_cents = 10_000
+    balance.average_balance_cents = 10_000
+    balance.as_of_at = Time.current
+    balance.save!
+  end
+
+  test "index renders workbench" do
+    get interest_accruals_url
+
+    assert_response :success
+    assert_select "h2", text: /Accrual Workbench/
+  end
+
+  test "run posts accruals through runner" do
+    assert_difference "InterestAccrual.count", 1 do
+      post run_interest_accruals_url
+    end
+
+    assert_response :success
+    assert_select "div", text: /Latest Run Summary/
+  end
+
+  private
+
+  def ensure_int_accrual_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "INT_ACCRUAL" })
+
+    transaction_code = TransactionCode.find_or_create_by!(code: "INT_ACCRUAL") do |record|
+      record.description = "Interest accrual"
+      record.reversal_code = "INT_ACCRUAL_REVERSAL"
+      record.active = true
+    end
+    posting_template = PostingTemplate.create!(
+      transaction_code: transaction_code,
+      name: "Interest Accrual",
+      description: "GL-only accrual",
+      active: true
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:four),
+      description: "Debit interest expense",
+      position: 0
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:five),
+      description: "Credit accrued interest payable",
+      position: 1
+    )
+  end
+end

--- a/test/controllers/interest_postings_controller_test.rb
+++ b/test/controllers/interest_postings_controller_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InterestPostingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    post login_url, params: { username: "testuser", password: "secret" }
+    travel_to Time.zone.local(2026, 3, 31, 12, 0, 0)
+
+    BusinessDate.update_all(status: Bankcore::Enums::BUSINESS_DATE_CLOSED)
+    ensure_business_date_open!(Date.new(2026, 3, 31))
+    ensure_int_post_template!
+
+    deposit_account = DepositAccount.find_or_initialize_by(account_id: accounts(:two).id)
+    deposit_account.deposit_type ||= accounts(:two).account_product.default_deposit_type
+    deposit_account.interest_bearing = true
+    deposit_account.save!
+
+    InterestAccrual.create!(
+      account: accounts(:two),
+      interest_rule: interest_rules(:savings_default),
+      accrual_date: Date.new(2026, 3, 30),
+      amount_cents: 250,
+      status: Bankcore::Enums::STATUS_POSTED
+    )
+  end
+
+  teardown do
+    travel_back
+  end
+
+  test "index renders due accounts" do
+    get interest_postings_url
+
+    assert_response :success
+    assert_select "h2", text: /Due Accounts/
+    assert_select "td", text: accounts(:two).account_number
+  end
+
+  test "create posts due interest and links accruals" do
+    assert_difference "InterestPostingApplication.count", 1 do
+      post interest_postings_url
+    end
+
+    assert_response :success
+    assert_select "div", text: /Latest Run Summary/
+  end
+
+  private
+
+  def ensure_business_date_open!(date)
+    BusinessDate.find_or_create_by!(business_date: date) do |business_date|
+      business_date.status = Bankcore::Enums::BUSINESS_DATE_OPEN
+      business_date.opened_at = Time.current
+    end
+  end
+
+  def ensure_int_post_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "INT_POST" })
+
+    transaction_code = TransactionCode.find_or_create_by!(code: "INT_POST") do |record|
+      record.description = "Interest posting"
+      record.reversal_code = "INT_POST_REVERSAL"
+      record.active = true
+    end
+    posting_template = PostingTemplate.create!(
+      transaction_code: transaction_code,
+      name: "Interest Posting",
+      description: "Debit payable, credit account",
+      active: true
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:five),
+      description: "Debit accrued interest payable",
+      position: 0
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Credit customer account",
+      position: 1
+    )
+  end
+end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
 class TransactionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     post login_url, params: { username: "testuser", password: "secret" }
+    ensure_ach_template!
+    ensure_fee_post_template!
   end
 
   test "index renders" do
@@ -17,6 +19,9 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "select#transaction_code"
     assert_select "input[name='transaction[amount]']"
+    assert_select "select[name='transaction[fee_type_id]']"
+    assert_select "input[name='transaction[ach_trace_number]']"
+    assert_select "a[href='#{interest_accruals_path}']"
   end
 
   test "create posts ADJ_CREDIT and redirects" do
@@ -68,6 +73,27 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=hidden][name='transaction[external_reference]'][value='CASE-99']"
   end
 
+  test "preview preserves fee and ach fields for confirm step" do
+    post transactions_url, params: {
+      preview: "1",
+      transaction: {
+        transaction_code: "ACH_DEBIT",
+        account_id: accounts(:one).id,
+        amount: "25.00",
+        ach_trace_number: "123456789012345",
+        ach_effective_date: "2026-03-08",
+        ach_batch_reference: "FILE-20260308",
+        authorization_reference: "AUTH-22",
+        authorization_source: "signed form"
+      }
+    }
+
+    assert_response :success
+    assert_select "input[type=hidden][name='transaction[ach_trace_number]'][value='123456789012345']"
+    assert_select "input[type=hidden][name='transaction[authorization_reference]'][value='AUTH-22']"
+    assert_select "input[type=hidden][name='transaction[ach_batch_reference]'][value='FILE-20260308']"
+  end
+
   test "show renders transaction" do
     txn = BankingTransaction.create!(
       transaction_type: "ADJ_CREDIT",
@@ -106,6 +132,56 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "reversal_threshold"
   end
 
+  test "create routes fee posts through fee workflow" do
+    assert_difference "FeeAssessment.count", 1 do
+      post transactions_url, params: {
+        transaction: {
+          transaction_code: "FEE_POST",
+          account_id: accounts(:one).id,
+          fee_type_id: fee_types(:maintenance).id,
+          memo: "Manual maintenance assessment",
+          reason_text: "Operator correction",
+          reference_number: "FEE-20260309-001"
+        }
+      }
+    end
+
+    assert_redirected_to transaction_path(BankingTransaction.last)
+    assessment = FeeAssessment.order(:id).last
+    assert_equal accounts(:one).id, assessment.account_id
+    assert_equal fee_types(:maintenance).id, assessment.fee_type_id
+  end
+
+  test "create routes ach entries through ach workflow" do
+    post transactions_url, params: {
+      transaction: {
+        transaction_code: "ACH_DEBIT",
+        account_id: accounts(:one).id,
+        amount: "42.50",
+        memo: "ACH debit",
+        ach_trace_number: "123456789012345",
+        ach_effective_date: "2026-03-08",
+        ach_batch_reference: "FILE-20260308",
+        authorization_reference: "AUTH-42",
+        authorization_source: "signed form"
+      }
+    }
+
+    assert_redirected_to transaction_path(BankingTransaction.last)
+    transaction = BankingTransaction.last
+    assert_equal "ACH_DEBIT", transaction.transaction_type
+    assert_equal(
+      [
+        "ach_batch_reference",
+        "ach_effective_date",
+        "ach_trace_number",
+        "authorization_reference",
+        "authorization_source"
+      ],
+      transaction.transaction_references.order(:reference_type).pluck(:reference_type)
+    )
+  end
+
   test "reverse requires reverse_transactions permission" do
     batch = PostingEngine.post!(
       transaction_code: "ADJ_CREDIT",
@@ -123,6 +199,21 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     assert_match /do not have permission/i, flash[:alert]
   end
 
+  test "reverse preview renders confirm screen" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 4000,
+      business_date: business_dates(:one).business_date
+    )
+
+    get reverse_preview_transaction_url(batch.operational_transaction)
+
+    assert_response :success
+    assert_select "h1", text: /Reversal Preview/
+    assert_select "form[action='#{reverse_transaction_path(batch.operational_transaction)}']"
+  end
+
   test "reverse redirects to override request when threshold exceeded without approval" do
     batch = PostingEngine.post!(
       transaction_code: "ADJ_CREDIT",
@@ -136,5 +227,64 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_override_request_path(transaction_id: txn.id, request_type: "reversal")
     assert_match /require supervisor approval/i, flash[:alert]
+  end
+
+  private
+
+  def ensure_fee_post_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "FEE_POST" })
+
+    posting_template = PostingTemplate.create!(
+      transaction_code: transaction_codes(:fee_post),
+      name: "Fee Assessment",
+      description: "Debit account, credit fee income",
+      active: true
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Debit customer account",
+      position: 0
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:three),
+      description: "Credit fee income",
+      position: 1
+    )
+  end
+
+  def ensure_ach_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "ACH_DEBIT" })
+
+    transaction_code = TransactionCode.find_or_create_by!(code: "ACH_DEBIT") do |record|
+      record.description = "Outgoing ACH"
+      record.reversal_code = "ACH_CREDIT"
+      record.active = true
+    end
+    posting_template = PostingTemplate.create!(
+      transaction_code: transaction_code,
+      name: "ACH Debit",
+      description: "Debit account, credit ACH clearing",
+      active: true
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Debit customer account",
+      position: 0
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:ten),
+      description: "Credit ACH clearing",
+      position: 1
+    )
   end
 end

--- a/test/services/transaction_entry/dispatcher_test.rb
+++ b/test/services/transaction_entry/dispatcher_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TransactionEntry::DispatcherTest < ActiveSupport::TestCase
+  setup do
+    ensure_fee_post_template!
+    ensure_ach_template!
+  end
+
+  test "posts fee workflow through fee posting service path" do
+    request = TransactionEntry::Request.from_form(
+      raw_params: {
+        transaction_code: "FEE_POST",
+        account_id: accounts(:one).id.to_s,
+        fee_type_id: fee_types(:maintenance).id.to_s,
+        reference_number: "FEE-REQ-1"
+      },
+      created_by_id: users(:one).id,
+      business_date: business_dates(:one).business_date
+    )
+
+    assert_difference "FeeAssessment.count", 1 do
+      batch = TransactionEntry::Dispatcher.post!(request: request)
+      assert_equal "FEE_POST", batch.transaction_code
+    end
+  end
+
+  test "previews ach workflow with structured context" do
+    request = TransactionEntry::Request.from_form(
+      raw_params: {
+        transaction_code: "ACH_DEBIT",
+        account_id: accounts(:one).id.to_s,
+        amount: "10.00",
+        ach_trace_number: "123456789012345",
+        ach_effective_date: "2026-03-08",
+        ach_batch_reference: "FILE-1",
+        authorization_reference: "AUTH-1"
+      },
+      created_by_id: users(:one).id,
+      business_date: business_dates(:one).business_date
+    )
+
+    preview = TransactionEntry::PreviewService.preview!(request: request)
+
+    assert_equal 1000, preview[:amount_cents]
+    assert_equal "123456789012345", preview[:context_rows].find { |label, _| label == "ACH Trace" }.last
+    assert_equal 2, preview[:legs].size
+  end
+
+  private
+
+  def ensure_fee_post_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "FEE_POST" })
+
+    posting_template = PostingTemplate.create!(
+      transaction_code: transaction_codes(:fee_post),
+      name: "Fee Assessment",
+      description: "Debit account, credit fee income",
+      active: true
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Debit customer account",
+      position: 0
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:three),
+      description: "Credit fee income",
+      position: 1
+    )
+  end
+
+  def ensure_ach_template!
+    return if PostingTemplate.joins(:transaction_code).exists?(transaction_codes: { code: "ACH_DEBIT" })
+
+    transaction_code = TransactionCode.find_or_create_by!(code: "ACH_DEBIT") do |record|
+      record.description = "Outgoing ACH"
+      record.reversal_code = "ACH_CREDIT"
+      record.active = true
+    end
+    posting_template = PostingTemplate.create!(
+      transaction_code: transaction_code,
+      name: "ACH Debit",
+      description: "Debit account, credit ACH clearing",
+      active: true
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_DEBIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_CUSTOMER,
+      description: "Debit customer account",
+      position: 0
+    )
+    PostingTemplateLeg.create!(
+      posting_template: posting_template,
+      leg_type: Bankcore::Enums::LEG_TYPE_CREDIT,
+      account_source: Bankcore::Enums::ACCOUNT_SOURCE_FIXED_GL,
+      gl_account: gl_accounts(:ten),
+      description: "Credit ACH clearing",
+      position: 1
+    )
+  end
+end

--- a/test/services/transaction_entry/request_test.rb
+++ b/test/services/transaction_entry/request_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TransactionEntry::RequestTest < ActiveSupport::TestCase
+  test "normalizes ids, amount, and dates from form params" do
+    request = TransactionEntry::Request.from_form(
+      raw_params: {
+        transaction_code: "ACH_DEBIT",
+        account_id: accounts(:one).id.to_s,
+        amount: "42.50",
+        ach_effective_date: "2026-03-08"
+      },
+      created_by_id: users(:one).id,
+      business_date: business_dates(:one).business_date
+    )
+
+    assert_equal "ACH_DEBIT", request.transaction_code
+    assert_equal accounts(:one).id, request.account_id
+    assert_equal 4250, request.amount_cents
+    assert_equal Date.new(2026, 3, 8), request.ach_effective_date
+    assert_equal :ach, request.family
+  end
+end


### PR DESCRIPTION
Closes #52.

## Summary
- add a transaction-entry request, policy, preview, and dispatcher layer so transaction workstation flows validate by family before posting
- route fee, ACH, interest, and reversal workflows through family-specific paths and dedicated operator screens where the shared shell is the wrong fit
- expand controller and service coverage to prove postings, side records, references, and review surfaces stay aligned

## Test plan
- [x] `bin/rails test test/controllers/transactions_controller_test.rb test/controllers/interest_accruals_controller_test.rb test/controllers/interest_postings_controller_test.rb test/services/transaction_entry/request_test.rb test/services/transaction_entry/dispatcher_test.rb`
- [x] `bin/rails test test/services/fee_posting_service_test.rb test/services/interest_accrual_service_test.rb test/services/interest_posting_service_test.rb test/services/interest_accrual_runner_service_test.rb test/services/interest_posting_runner_service_test.rb test/services/reversal_service_test.rb test/services/posting_engine_test.rb test/controllers/transactions_controller_test.rb test/controllers/interest_accruals_controller_test.rb test/controllers/interest_postings_controller_test.rb`
- [x] `bin/brakeman -q`

## Migration / Data Impact
- none

## Financial Logic Risk
- moderate: this changes the operator entry path and dispatcher routing, but preserves posting-engine ownership of financial truth and is covered by posting, fee, interest, and reversal regression tests

## Rollback Notes
- revert this branch or PR to restore the previous generic manual transaction entry path

## UI Notes
- workstation and review screens changed; screenshots not included in this PR

Made with [Cursor](https://cursor.com)