### PR TITLE
Add trial balance review with GL drilldown

### DIFF
--- a/app/controllers/trial_balances_controller.rb
+++ b/app/controllers/trial_balances_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class TrialBalancesController < ApplicationController
+  def index
+    load_report
+    @summary_rows = @trial_balance_query.summary_rows
+    @totals = @trial_balance_query.totals
+  end
+
+  def show
+    load_report
+    @gl_account = GlAccount.find(params[:id])
+    @summary_row = @trial_balance_query.summary_row_for(@gl_account.id)
+    @detail_rows = @trial_balance_query.detail_rows(gl_account_id: @gl_account.id)
+    @detail_totals = @trial_balance_query.detail_totals(gl_account_id: @gl_account.id)
+  end
+
+  private
+
+  def load_report
+    @business_date = resolved_business_date
+    @include_zero = include_zero?
+    @trial_balance_query = TrialBalanceQuery.new(
+      business_date: @business_date,
+      include_zero: @include_zero
+    )
+  end
+
+  def resolved_business_date
+    return BusinessDateService.current if params[:business_date].blank?
+
+    Date.iso8601(params[:business_date])
+  rescue ArgumentError
+    BusinessDateService.current
+  end
+
+  def include_zero?
+    params[:include_zero] != "0"
+  end
+end

--- a/app/queries/trial_balance_query.rb
+++ b/app/queries/trial_balance_query.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+class TrialBalanceQuery
+  SummaryRow = Struct.new(
+    :gl_account,
+    :debit_cents,
+    :credit_cents,
+    :net_cents,
+    :balance_side,
+    keyword_init: true
+  ) do
+    def net_amount_cents
+      net_cents.abs
+    end
+
+    def zero_activity?
+      debit_cents.zero? && credit_cents.zero?
+    end
+  end
+
+  DetailRow = Struct.new(
+    :journal_reference,
+    :posting_reference,
+    :business_date,
+    :posted_at,
+    :branch_name,
+    :debit_cents,
+    :credit_cents,
+    :transaction_type,
+    :transaction_reference_number,
+    :operational_transaction_id,
+    keyword_init: true
+  ) do
+    def net_cents
+      debit_cents - credit_cents
+    end
+
+    def net_amount_cents
+      net_cents.abs
+    end
+
+    def balance_side
+      return "debit" if net_cents.positive?
+      return "credit" if net_cents.negative?
+
+      "flat"
+    end
+  end
+
+  attr_reader :business_date, :include_zero
+
+  def initialize(business_date:, include_zero: true)
+    @business_date = business_date
+    @include_zero = include_zero
+  end
+
+  def summary_rows
+    @summary_rows ||= begin
+      aggregate_lookup = summary_aggregates_by_gl_account_id
+      rows = active_gl_accounts.map do |gl_account|
+        aggregate = aggregate_lookup.fetch(gl_account.id, {})
+        build_summary_row(
+          gl_account: gl_account,
+          debit_cents: aggregate[:debit_cents].to_i,
+          credit_cents: aggregate[:credit_cents].to_i
+        )
+      end
+
+      include_zero ? rows : rows.reject(&:zero_activity?)
+    end
+  end
+
+  def totals
+    rows = summary_rows
+
+    {
+      debit_cents: rows.sum(&:debit_cents),
+      credit_cents: rows.sum(&:credit_cents),
+      net_cents: rows.sum(&:net_cents)
+    }
+  end
+
+  def summary_row_for(gl_account_id)
+    summary_rows.find { |row| row.gl_account.id == gl_account_id.to_i } ||
+      build_summary_row(gl_account: active_gl_accounts.find(gl_account_id), debit_cents: 0, credit_cents: 0)
+  end
+
+  def detail_rows(gl_account_id:)
+    journal_lines_for(gl_account_id).map do |line|
+      posting_batch = line.journal_entry.posting_batch
+      operational_transaction = posting_batch.operational_transaction
+
+      DetailRow.new(
+        journal_reference: line.journal_entry.reference_number,
+        posting_reference: posting_batch.posting_reference,
+        business_date: line.journal_entry.business_date,
+        posted_at: line.journal_entry.posted_at,
+        branch_name: line.branch&.name,
+        debit_cents: line.debit_cents,
+        credit_cents: line.credit_cents,
+        transaction_type: operational_transaction&.transaction_type,
+        transaction_reference_number: operational_transaction&.reference_number,
+        operational_transaction_id: operational_transaction&.id
+      )
+    end
+  end
+
+  def detail_totals(gl_account_id:)
+    rows = detail_rows(gl_account_id: gl_account_id)
+
+    {
+      debit_cents: rows.sum(&:debit_cents),
+      credit_cents: rows.sum(&:credit_cents),
+      net_cents: rows.sum(&:net_cents)
+    }
+  end
+
+  private
+
+  def active_gl_accounts
+    @active_gl_accounts ||= GlAccount
+      .where(status: Bankcore::Enums::STATUS_ACTIVE)
+      .order(:gl_number)
+  end
+
+  def summary_aggregates_by_gl_account_id
+    JournalEntryLine
+      .joins(:journal_entry)
+      .where(journal_entries: { business_date: business_date })
+      .group(:gl_account_id)
+      .pluck(
+        :gl_account_id,
+        Arel.sql("COALESCE(SUM(journal_entry_lines.debit_cents), 0)"),
+        Arel.sql("COALESCE(SUM(journal_entry_lines.credit_cents), 0)")
+      )
+      .each_with_object({}) do |(gl_account_id, debit_cents, credit_cents), result|
+        result[gl_account_id] = {
+          debit_cents: debit_cents.to_i,
+          credit_cents: credit_cents.to_i
+        }
+      end
+  end
+
+  def journal_lines_for(gl_account_id)
+    JournalEntryLine
+      .includes(:branch, journal_entry: { posting_batch: :operational_transaction })
+      .joins(:journal_entry)
+      .where(gl_account_id: gl_account_id, journal_entries: { business_date: business_date })
+      .order(Arel.sql("journal_entries.posted_at ASC, journal_entry_lines.position ASC, journal_entry_lines.id ASC"))
+  end
+
+  def build_summary_row(gl_account:, debit_cents:, credit_cents:)
+    net_cents = debit_cents - credit_cents
+
+    SummaryRow.new(
+      gl_account: gl_account,
+      debit_cents: debit_cents,
+      credit_cents: credit_cents,
+      net_cents: net_cents,
+      balance_side: balance_side_for(net_cents)
+    )
+  end
+
+  def balance_side_for(net_cents)
+    return "debit" if net_cents.positive?
+    return "credit" if net_cents.negative?
+
+    "flat"
+  end
+end

--- a/app/views/gl_accounts/index.html.erb
+++ b/app/views/gl_accounts/index.html.erb
@@ -15,7 +15,10 @@
         <h2 class="text-lg font-semibold text-base-content">GL Register</h2>
         <p class="mt-1 text-sm text-base-content/65">Active general ledger accounts in numeric order.</p>
       </div>
-      <span class="ui-status-pill ui-status-pill-neutral"><%= @gl_accounts.size %> Accounts</span>
+      <div class="flex items-center gap-2">
+        <span class="ui-status-pill ui-status-pill-neutral"><%= @gl_accounts.size %> Accounts</span>
+        <%= link_to "View Trial Balance", trial_balances_path, class: "btn btn-ghost btn-sm" %>
+      </div>
     </div>
 
     <div class="ui-panel-body">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,9 @@
               <%= link_to gl_accounts_path, class: app_nav_link_class(gl_accounts_path) do %>
                 <span>GL Accounts</span>
               <% end %>
+              <%= link_to trial_balances_path, class: app_nav_link_class(trial_balances_path) do %>
+                <span>Trial Balance</span>
+              <% end %>
               <%= link_to fee_assessments_path, class: app_nav_link_class(fee_assessments_path) do %>
                 <span>Fee Assessments</span>
               <% end %>

--- a/app/views/trial_balances/index.html.erb
+++ b/app/views/trial_balances/index.html.erb
@@ -1,0 +1,111 @@
+<% content_for :title, "Trial Balance - BankCORE" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back", root_path, class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">Trial Balance</h1>
+      <p class="workspace-subtitle">Review posted GL activity by account using journal projections, then drill into the underlying transaction register.</p>
+    </div>
+  </div>
+
+  <section class="ui-panel mb-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Filter</h2>
+        <p class="mt-1 text-sm text-base-content/65">Defaulting to the current business date keeps the first slice tight while preserving room for richer report filters later.</p>
+      </div>
+    </div>
+
+    <div class="ui-panel-body">
+      <%= form_with url: trial_balances_path, method: :get, local: true, class: "grid gap-4 lg:grid-cols-3 lg:items-end" do %>
+        <div class="form-control w-full">
+          <label class="label" for="business_date">
+            <span class="label-text text-sm font-medium">Business Date</span>
+          </label>
+          <input type="date" name="business_date" id="business_date" value="<%= @business_date&.iso8601 %>" class="input input-bordered w-full ui-mono">
+        </div>
+
+        <div class="form-control w-full">
+          <label class="label cursor-pointer justify-start gap-3 pt-8">
+            <input type="checkbox" name="include_zero" value="1" <%= "checked" if @include_zero %> class="checkbox checkbox-sm">
+            <span class="label-text text-sm font-medium">Show zero-activity accounts</span>
+          </label>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <button type="submit" class="btn btn-primary">Refresh</button>
+          <%= link_to "Reset", trial_balances_path, class: "btn btn-ghost" %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <div class="grid gap-4 lg:grid-cols-4 mb-6">
+    <div class="ui-metric">
+      <div class="ui-metric-label">Business Date</div>
+      <div class="ui-metric-value ui-mono"><%= @business_date&.strftime("%Y-%m-%d") %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Total Debits</div>
+      <div class="ui-metric-value ui-mono"><%= number_to_currency(@totals[:debit_cents] / 100.0) %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Total Credits</div>
+      <div class="ui-metric-value ui-mono"><%= number_to_currency(@totals[:credit_cents] / 100.0) %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Difference</div>
+      <div class="ui-metric-value ui-mono"><%= number_to_currency((@totals[:debit_cents] - @totals[:credit_cents]).abs / 100.0) %></div>
+    </div>
+  </div>
+
+  <section class="ui-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">GL Summary</h2>
+        <p class="mt-1 text-sm text-base-content/65">Debit, credit, and net position by active GL account for the selected business date.</p>
+      </div>
+      <span class="ui-status-pill ui-status-pill-neutral"><%= @summary_rows.size %> Rows</span>
+    </div>
+
+    <div class="ui-panel-body">
+      <table class="ui-ledger-table">
+        <thead>
+          <tr>
+            <th>GL Number</th>
+            <th>Name</th>
+            <th>Category</th>
+            <th>Normal</th>
+            <th class="text-right">Debit</th>
+            <th class="text-right">Credit</th>
+            <th class="text-right">Net</th>
+            <th>Side</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @summary_rows.each do |row| %>
+            <tr>
+              <td class="ui-mono"><%= row.gl_account.gl_number %></td>
+              <td><%= row.gl_account.name %></td>
+              <td><%= row.gl_account.category %></td>
+              <td><%= row.gl_account.normal_balance %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(row.debit_cents / 100.0) %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(row.credit_cents / 100.0) %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(row.net_amount_cents / 100.0) %></td>
+              <td><span class="<%= status_pill_class(row.balance_side == "flat" ? "neutral" : "active") %>"><%= row.balance_side %></span></td>
+              <td>
+                <%= link_to "Drilldown", trial_balance_path(row.gl_account, business_date: @business_date, include_zero: (@include_zero ? 1 : 0)), class: "btn btn-ghost btn-xs" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <% if @summary_rows.empty? %>
+        <p class="mt-4 text-sm text-base-content/60">No trial balance rows for the selected filter.</p>
+      <% end %>
+    </div>
+  </section>
+</div>

--- a/app/views/trial_balances/show.html.erb
+++ b/app/views/trial_balances/show.html.erb
@@ -1,0 +1,124 @@
+<% content_for :title, "Trial Balance Detail - #{@gl_account.gl_number}" %>
+
+<div class="w-full">
+  <div class="workspace-header">
+    <div>
+      <%= link_to "← Back to Trial Balance", trial_balances_path(business_date: @business_date, include_zero: (@include_zero ? 1 : 0)), class: "link link-primary mb-2 inline-block text-sm" %>
+      <h1 class="workspace-title">G/L Drilldown</h1>
+      <p class="workspace-subtitle">Inspect the journal-line activity that makes up the trial balance position for a single GL account.</p>
+    </div>
+  </div>
+
+  <div class="grid gap-4 lg:grid-cols-5 mb-6">
+    <div class="ui-metric">
+      <div class="ui-metric-label">GL Number</div>
+      <div class="ui-metric-value ui-mono"><%= @gl_account.gl_number %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Category</div>
+      <div class="ui-metric-value"><%= @gl_account.category %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Normal Balance</div>
+      <div class="ui-metric-value"><%= @gl_account.normal_balance %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Business Date</div>
+      <div class="ui-metric-value ui-mono"><%= @business_date&.strftime("%Y-%m-%d") %></div>
+    </div>
+    <div class="ui-metric">
+      <div class="ui-metric-label">Net</div>
+      <div class="ui-metric-value ui-mono"><%= number_to_currency(@summary_row.net_amount_cents / 100.0) %></div>
+    </div>
+  </div>
+
+  <section class="ui-panel mb-6">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content"><%= @gl_account.name %></h2>
+        <p class="mt-1 text-sm text-base-content/65">Summary totals for the selected GL account on the chosen business date.</p>
+      </div>
+    </div>
+
+    <div class="ui-panel-body">
+      <div class="grid gap-4 lg:grid-cols-3">
+        <div class="ui-kv-row">
+          <div class="ui-kv-label">Debit Total</div>
+          <div class="ui-kv-value ui-mono"><%= number_to_currency(@summary_row.debit_cents / 100.0) %></div>
+        </div>
+        <div class="ui-kv-row">
+          <div class="ui-kv-label">Credit Total</div>
+          <div class="ui-kv-value ui-mono"><%= number_to_currency(@summary_row.credit_cents / 100.0) %></div>
+        </div>
+        <div class="ui-kv-row">
+          <div class="ui-kv-label">Balance Side</div>
+          <div class="ui-kv-value"><span class="<%= status_pill_class(@summary_row.balance_side == "flat" ? "neutral" : "active") %>"><%= @summary_row.balance_side %></span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="ui-panel">
+    <div class="ui-panel-header">
+      <div>
+        <h2 class="text-lg font-semibold text-base-content">Journal Register</h2>
+        <p class="mt-1 text-sm text-base-content/65">Projected journal lines for this GL account. Use transaction links to jump into the originating operational review screen.</p>
+      </div>
+      <span class="ui-status-pill ui-status-pill-neutral"><%= @detail_rows.size %> Rows</span>
+    </div>
+
+    <div class="ui-panel-body">
+      <table class="ui-ledger-table">
+        <thead>
+          <tr>
+            <th>Journal Ref</th>
+            <th>Posting Ref</th>
+            <th>Posted At</th>
+            <th>Branch</th>
+            <th>Txn Type</th>
+            <th>Txn Ref</th>
+            <th class="text-right">Debit</th>
+            <th class="text-right">Credit</th>
+            <th class="text-right">Net</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @detail_rows.each do |row| %>
+            <tr>
+              <td class="ui-mono"><%= row.journal_reference %></td>
+              <td class="ui-mono"><%= row.posting_reference %></td>
+              <td class="ui-mono"><%= row.posted_at&.strftime("%Y-%m-%d %H:%M") || "—" %></td>
+              <td><%= row.branch_name || "—" %></td>
+              <td><%= row.transaction_type || "—" %></td>
+              <td class="ui-mono"><%= row.transaction_reference_number || "—" %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(row.debit_cents / 100.0) %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(row.credit_cents / 100.0) %></td>
+              <td class="ui-mono text-right"><%= number_to_currency(row.net_amount_cents / 100.0) %></td>
+              <td>
+                <% if row.operational_transaction_id.present? %>
+                  <%= link_to "Txn", transaction_path(row.operational_transaction_id), class: "btn btn-ghost btn-xs" %>
+                <% else %>
+                  <span class="text-sm text-base-content/50">No txn</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="6">Detail Total</td>
+            <td class="ui-mono text-right"><%= number_to_currency(@detail_totals[:debit_cents] / 100.0) %></td>
+            <td class="ui-mono text-right"><%= number_to_currency(@detail_totals[:credit_cents] / 100.0) %></td>
+            <td class="ui-mono text-right"><%= number_to_currency(@detail_totals[:net_cents].abs / 100.0) %></td>
+            <td></td>
+          </tr>
+        </tfoot>
+      </table>
+
+      <% if @detail_rows.empty? %>
+        <p class="mt-4 text-sm text-base-content/60">No journal lines for this GL account on the selected business date.</p>
+      <% end %>
+    </div>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   resources :audit_events, only: %i[index], path: "audit-events"
   resources :branches, only: %i[index show]
   resources :gl_accounts, only: %i[index], path: "gl-accounts"
+  resources :trial_balances, only: %i[index show], path: "trial-balance"
 
   resources :override_requests, only: %i[index show new create] do
     member do

--- a/test/controllers/trial_balances_controller_test.rb
+++ b/test/controllers/trial_balances_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TrialBalancesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    post login_url, params: { username: "testuser", password: "secret" }
+  end
+
+  test "index renders trial balance summary and drilldown links" do
+    PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 1_500,
+      business_date: business_dates(:one).business_date,
+      reference_number: "TB-CONTROLLER-1"
+    )
+
+    get trial_balances_url
+
+    assert_response :success
+    assert_select "h1", text: /Trial Balance/
+    assert_select "td", text: "5190"
+    assert_select "a[href='#{trial_balance_path(GlAccount.find_by!(gl_number: "5190"), business_date: business_dates(:one).business_date, include_zero: 1)}']"
+  end
+
+  test "index hides zero rows when include_zero is disabled" do
+    get trial_balances_url, params: { business_date: business_dates(:one).business_date, include_zero: "0" }
+
+    assert_response :success
+    assert_select "p", text: /No trial balance rows/
+  end
+
+  test "show renders drilldown register with transaction links" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 2_100,
+      business_date: business_dates(:one).business_date,
+      reference_number: "TB-CONTROLLER-2"
+    )
+    gl_account = GlAccount.find_by!(gl_number: "5190")
+
+    get trial_balance_url(gl_account), params: { business_date: business_dates(:one).business_date }
+
+    assert_response :success
+    assert_select "h1", text: /G\/L Drilldown/
+    assert_select "td", text: batch.posting_reference
+    assert_select "a[href='#{transaction_path(batch.operational_transaction_id)}']"
+  end
+end

--- a/test/queries/trial_balance_query_test.rb
+++ b/test/queries/trial_balance_query_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TrialBalanceQueryTest < ActiveSupport::TestCase
+  test "summary rows aggregate debit and credit totals by gl account" do
+    PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 1_250,
+      business_date: business_dates(:one).business_date,
+      reference_number: "TB-001"
+    )
+
+    query = TrialBalanceQuery.new(business_date: business_dates(:one).business_date, include_zero: true)
+    expense_row = query.summary_rows.find { |row| row.gl_account.gl_number == "5190" }
+    liability_row = query.summary_rows.find { |row| row.gl_account.gl_number == "2110" }
+
+    assert_equal 1_250, expense_row.debit_cents
+    assert_equal 0, expense_row.credit_cents
+    assert_equal "debit", expense_row.balance_side
+
+    assert_equal 0, liability_row.debit_cents
+    assert_equal 1_250, liability_row.credit_cents
+    assert_equal "credit", liability_row.balance_side
+    assert_equal query.totals[:debit_cents], query.totals[:credit_cents]
+  end
+
+  test "include_zero false hides inactive summary rows" do
+    query = TrialBalanceQuery.new(business_date: business_dates(:one).business_date, include_zero: false)
+
+    assert_empty query.summary_rows
+  end
+
+  test "detail rows expose posting and transaction context" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 2_000,
+      business_date: business_dates(:one).business_date,
+      reference_number: "TB-DETAIL-1"
+    )
+
+    gl_account = GlAccount.find_by!(gl_number: "5190")
+    detail_row = TrialBalanceQuery
+      .new(business_date: business_dates(:one).business_date, include_zero: true)
+      .detail_rows(gl_account_id: gl_account.id)
+      .first
+
+    assert_equal batch.posting_reference, detail_row.posting_reference
+    assert_equal "ADJ_CREDIT", detail_row.transaction_type
+    assert_equal "TB-DETAIL-1", detail_row.transaction_reference_number
+    assert_equal batch.operational_transaction_id, detail_row.operational_transaction_id
+  end
+
+  test "reversal activity appears as offsetting journal lines on the customer liability gl" do
+    batch = PostingEngine.post!(
+      transaction_code: "ADJ_CREDIT",
+      account_id: accounts(:one).id,
+      amount_cents: 1_000,
+      business_date: business_dates(:one).business_date
+    )
+    ReversalService.reverse!(posting_batch: batch)
+
+    gl_account = GlAccount.find_by!(gl_number: "2110")
+    row = TrialBalanceQuery
+      .new(business_date: business_dates(:one).business_date, include_zero: true)
+      .summary_row_for(gl_account.id)
+
+    assert_equal 1_000, row.debit_cents
+    assert_equal 1_000, row.credit_cents
+    assert_equal 0, row.net_cents
+    assert_equal "flat", row.balance_side
+  end
+end


### PR DESCRIPTION
Closes #54.

## Summary
- add a trial balance report backed by journal projections so operators can review debit, credit, and net balances by GL account
- add GL-account drilldown that shows the contributing journal register and links back to originating transaction review when available
- wire the report into back-office navigation and add tests covering totals, filters, and reversal reporting behavior

## Test plan
- [x] `bin/rails test test/queries/trial_balance_query_test.rb test/controllers/trial_balances_controller_test.rb`
- [x] `bin/rails test test/queries/trial_balance_query_test.rb test/controllers/trial_balances_controller_test.rb test/services/journal_projector_test.rb test/services/reversal_service_test.rb test/controllers/transactions_controller_test.rb`
- [x] `bin/brakeman -q`

## Migration / Data Impact
- none

## Financial Logic Risk
- low to moderate: this is a read-only reporting surface over `journal_entry_lines`, but its correctness depends on preserving existing journal projection and reversal semantics

## Rollback Notes
- revert this branch or PR to remove the trial balance routes, views, and query object and fall back to the existing GL account register only

## UI Notes
- adds new back-office report screens; screenshots not included in this PR

Made with [Cursor](https://cursor.com)