### PR TITLE
Refactor workspace navigation context

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -77,6 +77,22 @@
     @apply sticky top-0 z-30 flex flex-col gap-4 border-b border-base-300 bg-white/95 px-5 py-4 backdrop-blur lg:px-8;
   }
 
+  .workspace-contextbar {
+    @apply flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500;
+  }
+
+  .workspace-context-item {
+    @apply text-slate-500;
+  }
+
+  .workspace-context-item-active {
+    @apply text-primary;
+  }
+
+  .workspace-context-separator {
+    @apply text-slate-400;
+  }
+
   .workspace-statusbar {
     @apply flex flex-wrap items-center gap-2 text-xs font-medium text-slate-600;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  AppNavLink = Struct.new(:label, :path, :path_prefixes, keyword_init: true)
+
   def current_business_date
     BusinessDateService.current.strftime("%Y-%m-%d")
   rescue BusinessDateService::NoOpenBusinessDateError
@@ -43,8 +45,67 @@ module ApplicationHelper
     "ui-status-pill ui-status-pill-#{variant}"
   end
 
-  def app_nav_link_class(path)
-    active = current_page?(path) || request.path.start_with?(path)
+  def app_nav_link_class(path:, path_prefixes: nil)
+    active = app_nav_active_for?(path: path, path_prefixes: path_prefixes)
     active ? "app-nav-link app-nav-link-active" : "app-nav-link"
+  end
+
+  def app_navigation_sections
+    @app_navigation_sections ||= [
+      {
+        label: "Primary Workspace",
+        links: [
+          AppNavLink.new(label: "Transactions", path: transactions_path),
+          AppNavLink.new(label: "Business Dates", path: business_dates_path),
+          AppNavLink.new(label: "Overrides", path: override_requests_path)
+        ]
+      },
+      {
+        label: "Customer Operations",
+        links: [
+          AppNavLink.new(label: "Accounts", path: accounts_path),
+          AppNavLink.new(label: "New Account", path: new_account_path),
+          AppNavLink.new(label: "Parties", path: parties_path),
+          AppNavLink.new(label: "Branches", path: branches_path)
+        ]
+      },
+      {
+        label: "Back Office Review",
+        links: [
+          AppNavLink.new(label: "Account Products", path: account_products_path),
+          AppNavLink.new(label: "Fee Types", path: fee_types_path),
+          AppNavLink.new(label: "GL Accounts", path: gl_accounts_path),
+          AppNavLink.new(label: "Trial Balance", path: trial_balances_path),
+          AppNavLink.new(label: "Fee Assessments", path: fee_assessments_path),
+          AppNavLink.new(label: "Interest Accruals", path: interest_accruals_path),
+          AppNavLink.new(label: "Interest Postings", path: interest_postings_path),
+          AppNavLink.new(label: "Audit Events", path: audit_events_path)
+        ]
+      }
+    ]
+  end
+
+  def app_current_nav_section
+    app_navigation_sections.find do |section|
+      section[:links].any? do |link|
+        app_nav_active_for?(path: link.path, path_prefixes: link.path_prefixes)
+      end
+    end
+  end
+
+  def app_current_nav_link
+    app_current_nav_section&.fetch(:links)&.find do |link|
+      app_nav_active_for?(path: link.path, path_prefixes: link.path_prefixes)
+    end
+  end
+
+  def app_nav_active_for?(path:, path_prefixes: nil)
+    return true if current_page?(path)
+
+    prefixes = Array(path_prefixes.presence || path).map { |prefix| prefix.to_s.chomp("/") }
+    current_path = request.path.to_s.chomp("/")
+    prefixes.any? do |prefix|
+      current_path == prefix || current_path.start_with?("#{prefix}/")
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,8 @@
   <body data-theme="bankcore">
     <% page_title = (content_for(:title).presence || "BankCORE").sub(/ - BankCORE\z/, "") %>
     <% if current_user %>
+      <% current_section = app_current_nav_section %>
+      <% current_link = app_current_nav_link %>
       <div class="app-shell">
         <aside class="app-sidebar">
           <div class="app-sidebar-brand">
@@ -37,62 +39,16 @@
           </div>
 
           <nav class="app-sidebar-nav">
-            <div class="app-sidebar-section">
-              <div class="app-sidebar-label">Primary Workspace</div>
-              <%= link_to transactions_path, class: app_nav_link_class(transactions_path) do %>
-                <span>Transactions</span>
-              <% end %>
-              <%= link_to business_dates_path, class: app_nav_link_class(business_dates_path) do %>
-                <span>Business Dates</span>
-              <% end %>
-              <%= link_to override_requests_path, class: app_nav_link_class(override_requests_path) do %>
-                <span>Overrides</span>
-              <% end %>
-            </div>
-
-            <div class="app-sidebar-section">
-              <div class="app-sidebar-label">Customer Operations</div>
-              <%= link_to accounts_path, class: app_nav_link_class(accounts_path) do %>
-                <span>Accounts</span>
-              <% end %>
-              <%= link_to new_account_path, class: app_nav_link_class(new_account_path) do %>
-                <span>New Account</span>
-              <% end %>
-              <%= link_to parties_path, class: app_nav_link_class(parties_path) do %>
-                <span>Parties</span>
-              <% end %>
-              <%= link_to branches_path, class: app_nav_link_class(branches_path) do %>
-                <span>Branches</span>
-              <% end %>
-            </div>
-
-            <div class="app-sidebar-section">
-              <div class="app-sidebar-label">Back Office Review</div>
-              <%= link_to account_products_path, class: app_nav_link_class(account_products_path) do %>
-                <span>Account Products</span>
-              <% end %>
-              <%= link_to fee_types_path, class: app_nav_link_class(fee_types_path) do %>
-                <span>Fee Types</span>
-              <% end %>
-              <%= link_to gl_accounts_path, class: app_nav_link_class(gl_accounts_path) do %>
-                <span>GL Accounts</span>
-              <% end %>
-              <%= link_to trial_balances_path, class: app_nav_link_class(trial_balances_path) do %>
-                <span>Trial Balance</span>
-              <% end %>
-              <%= link_to fee_assessments_path, class: app_nav_link_class(fee_assessments_path) do %>
-                <span>Fee Assessments</span>
-              <% end %>
-              <%= link_to interest_accruals_path, class: app_nav_link_class(interest_accruals_path) do %>
-                <span>Interest Accruals</span>
-              <% end %>
-              <%= link_to interest_postings_path, class: app_nav_link_class(interest_postings_path) do %>
-                <span>Interest Postings</span>
-              <% end %>
-              <%= link_to audit_events_path, class: app_nav_link_class(audit_events_path) do %>
-                <span>Audit Events</span>
-              <% end %>
-            </div>
+            <% app_navigation_sections.each do |section| %>
+              <div class="app-sidebar-section">
+                <div class="app-sidebar-label"><%= section[:label] %></div>
+                <% section[:links].each do |link| %>
+                  <%= link_to link.path, class: app_nav_link_class(path: link.path, path_prefixes: link.path_prefixes) do %>
+                    <span><%= link.label %></span>
+                  <% end %>
+                <% end %>
+              </div>
+            <% end %>
           </nav>
 
           <div class="app-sidebar-footer">
@@ -103,6 +59,18 @@
 
         <div class="workspace-main">
           <header class="app-topbar">
+            <div class="workspace-contextbar">
+              <span class="workspace-context-item">Workspace</span>
+              <% if current_section %>
+                <span class="workspace-context-separator">/</span>
+                <span class="workspace-context-item"><%= current_section[:label] %></span>
+              <% end %>
+              <% if current_link %>
+                <span class="workspace-context-separator">/</span>
+                <span class="workspace-context-item workspace-context-item-active"><%= current_link.label %></span>
+              <% end %>
+            </div>
+
             <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
               <div>
                 <div class="text-lg font-semibold tracking-tight text-base-content"><%= page_title %></div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "app_nav_link_class treats nested paths as active" do
+    with_nav_context("/trial-balance/1") do
+      assert_equal "app-nav-link app-nav-link-active", app_nav_link_class(path: trial_balances_path)
+    end
+  end
+
+  test "current navigation resolves section and link from nested report paths" do
+    with_nav_context("/trial-balance/1") do
+      assert_equal "Back Office Review", app_current_nav_section[:label]
+      assert_equal "Trial Balance", app_current_nav_link.label
+    end
+  end
+
+  private
+
+  def with_nav_context(current_path)
+    request_stub = Struct.new(:path).new(current_path)
+    singleton_class.define_method(:request) { request_stub }
+    singleton_class.define_method(:current_page?) { |path| path.to_s == current_path }
+    yield
+  ensure
+    singleton_class.send(:remove_method, :request) if singleton_class.instance_methods(false).include?(:request)
+    singleton_class.send(:remove_method, :current_page?) if singleton_class.instance_methods(false).include?(:current_page?)
+  end
+end


### PR DESCRIPTION
Closes #56.

## Summary
- centralize workstation navigation sections and links in `ApplicationHelper` instead of hardcoding the sidebar layout
- add a top workspace context bar and make sidebar active-state matching use the same path-resolution logic as the context helpers
- add focused helper coverage for nested-path navigation state

## Test plan
- [x] `bin/rails test test/helpers/application_helper_test.rb test/controllers/trial_balances_controller_test.rb test/controllers/transactions_controller_test.rb`

## Migration / Data Impact
- none

## Financial Logic Risk
- low: this is a UI/helper refactor only and does not change posting, projection, or operational workflows

## Rollback Notes
- revert this branch or PR to restore the previous hardcoded sidebar and topbar structure

## UI Notes
- updates workspace navigation and adds a breadcrumb-style context bar; screenshots not included in this PR

Made with [Cursor](https://cursor.com)