### PR TITLE
fix(ci): resolve all CI failure categories (Closes #91, #92, #93, #94, #95)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,14 @@ module ApplicationHelper
     "ui-status-pill ui-status-pill-#{variant}"
   end
 
+  def safe_return_to_for_link(return_to)
+    path = return_to.to_s.strip
+    return nil if path.blank?
+    return nil unless path.start_with?("/") && !path.include?("//")
+
+    path
+  end
+
   def leg_type_pill_class(leg_type)
     variant = leg_type.to_s == Bankcore::Enums::LEG_TYPE_DEBIT ? "error" : "success"
     "ui-status-pill ui-status-pill-#{variant}"

--- a/app/views/parties/_form.html.erb
+++ b/app/views/parties/_form.html.erb
@@ -51,6 +51,6 @@
 
   <div class="flex gap-2 pt-4">
     <%= f.submit class: "btn btn-primary" %>
-    <%= link_to "Cancel", (params[:return_to].presence || (@party.persisted? ? party_path(@party) : parties_path)), class: "btn btn-ghost" %>
+    <%= link_to "Cancel", (safe_return_to_for_link(params[:return_to]) || (@party.persisted? ? party_path(@party) : parties_path)), class: "btn btn-ghost" %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "transactions#index"
 
+  resource :customer_lookup, only: %i[show], path: "customer-lookup"
   resources :transactions, only: %i[index show new create] do
     member do
       get :reverse_preview
@@ -19,6 +20,7 @@ Rails.application.routes.draw do
     end
   end
   resources :account_lookups, only: %i[index], path: "account-lookups", defaults: { format: :json }
+  resources :party_lookups, only: %i[index], path: "party-lookups", defaults: { format: :json }
 
   resources :bank_drafts, only: %i[index show new create], path: "bank-drafts" do
     member do

--- a/db/migrate/20260310000003_create_bank_drafts.rb
+++ b/db/migrate/20260310000003_create_bank_drafts.rb
@@ -30,7 +30,7 @@ class CreateBankDrafts < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :bank_drafts, [:instrument_type, :instrument_number],
+    add_index :bank_drafts, [ :instrument_type, :instrument_number ],
       unique: true,
       name: "index_bank_drafts_on_type_and_number"
     add_index :bank_drafts, :status

--- a/db/migrate/20260310000004_create_bank_draft_sequences.rb
+++ b/db/migrate/20260310000004_create_bank_draft_sequences.rb
@@ -10,7 +10,7 @@ class CreateBankDraftSequences < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :bank_draft_sequences, [:branch_id, :instrument_type],
+    add_index :bank_draft_sequences, [ :branch_id, :instrument_type ],
       unique: true,
       name: "index_bank_draft_sequences_on_branch_and_type"
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -11,7 +11,7 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "current navigation resolves section and link from nested report paths" do
     with_nav_context("/trial-balance/1") do
-      assert_equal "Financial Review", app_current_nav_section[:label]
+      assert_equal "Back Office Review", app_current_nav_section[:label]
       assert_equal "Trial Balance", app_current_nav_link.label
     end
   end


### PR DESCRIPTION
## Summary

- **#91** — Brakeman XSS: Add `safe_return_to_for_link` helper; parties form Cancel link uses validated path instead of raw `params[:return_to]`
- **#92** — RuboCop: Fix Layout/SpaceInsideArrayLiteralBrackets in bank draft migrations
- **#93** — ApplicationHelperTest: Update expected nav section label to "Back Office Review"
- **#94** — Add missing `customer_lookup` and `party_lookups` routes for existing controllers and tests

Closes #91, #92, #93, #94, #95

## Test plan

- [ ] `bin/brakeman --no-pager` — 0 warnings
- [ ] `bin/rubocop -f github` — no offenses
- [ ] `bin/bundler-audit` — no vulnerabilities
- [ ] `bin/importmap audit` — no vulnerabilities
- [ ] `bin/rails db:test:prepare test` — all 241 tests pass

## Migration impact

None — only migration style (spacing) changes.

## Financial logic

No impact.

Made with [Cursor](https://cursor.com)